### PR TITLE
feat(frontend): スポット投稿画面の作成

### DIFF
--- a/backend/src/category/category.resolver.ts
+++ b/backend/src/category/category.resolver.ts
@@ -4,10 +4,15 @@ import { CategoryService } from './category.service';
 import { UseGuards } from '@nestjs/common';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 import { GqlAuthGuard } from 'src/auth/auth.guard';
+import { AttributeTag, MoodTag } from './dto/tag.object';
+import { PrismaService } from 'prisma/prisma.service';
 
 @Resolver(() => Category)
 export class CategoryResolver {
-  constructor(private categoryService: CategoryService) {}
+  constructor(
+    private prisma: PrismaService,
+    private categoryService: CategoryService,
+  ) {}
 
   @Query(() => [Category], { name: 'categories' })
   async getCategories() {
@@ -23,5 +28,19 @@ export class CategoryResolver {
   @UseGuards(GqlAuthGuard)
   whoAmI(@CurrentUser() user: { supabaseId: string; email: string }) {
     return `You are: ${user.email} (Supabase ID: ${user.supabaseId})`;
+  }
+
+  @Query(() => [AttributeTag], { name: 'attributeTags' })
+  getAttributeTags() {
+    return this.prisma.attributeTag.findMany({
+      orderBy: { displayOrder: 'asc' },
+    });
+  }
+
+  @Query(() => [MoodTag], { name: 'moodTags' })
+  getMoodTags() {
+    return this.prisma.moodTag.findMany({
+      orderBy: { displayOrder: 'asc' },
+    });
   }
 }

--- a/backend/src/category/dto/tag.object.ts
+++ b/backend/src/category/dto/tag.object.ts
@@ -1,0 +1,31 @@
+import { ObjectType, Field, ID, Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class AttributeTag {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  name: string;
+
+  @Field()
+  slug: string;
+
+  @Field(() => Int)
+  displayOrder: number;
+}
+
+@ObjectType()
+export class MoodTag {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  name: string;
+
+  @Field()
+  slug: string;
+
+  @Field(() => Int)
+  displayOrder: number;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "graphql": "^16.13.1",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "react-hook-form": "^7.72.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/frontend/src/app/(main)/spots/new/page.tsx
+++ b/frontend/src/app/(main)/spots/new/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useAuth } from "@/hooks/useAuth";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { SpotForm } from "@/components/spot/SpotForm";
+
+export default function NewSpotPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/login");
+    }
+  }, [user, loading, router]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-8 px-4">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold text-gray-900 mb-8">
+          スポットを投稿
+        </h1>
+        <SpotForm />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/spot/SpotForm.tsx
+++ b/frontend/src/components/spot/SpotForm.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { useMutation, useQuery } from "@apollo/client/react";
+import { CREATE_SPOT } from "@/graphql/mutations/spot";
+import { GET_ALL_TAGS } from "@/graphql/queries/tag";
+import { ImageUploader } from "@/components/common/ImageUploader";
+
+interface SpotFormData {
+  title: string;
+  description: string;
+  address: string;
+  categoryId: string;
+  priceRange: number | null;
+  businessHours: string;
+  attributeTagIds: string[];
+  moodTagIds: string[];
+}
+
+interface CreateSpotResult {
+  createSpot: {
+    id: string;
+    title: string;
+  };
+}
+
+interface GetAllTagsResult {
+  categories: { id: string; name: string; slug: string }[];
+  attributeTags: { id: string; name: string; slug: string }[];
+  moodTags: { id: string; name: string; slug: string }[];
+}
+
+export function SpotForm() {
+  const router = useRouter();
+
+  const [imageUrls, setImageUrls] = useState<string[]>([]);
+
+  const { data: tagData, loading: tagLoading } =
+    useQuery<GetAllTagsResult>(GET_ALL_TAGS);
+
+  const [createSpot, { loading: creating }] =
+    useMutation<CreateSpotResult>(CREATE_SPOT);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useForm<SpotFormData>({
+    defaultValues: {
+      title: "",
+      description: "",
+      address: "",
+      categoryId: "",
+      priceRange: null,
+      businessHours: "",
+      attributeTagIds: [],
+      moodTagIds: [],
+    },
+  });
+
+  const selectedAttributeTags = watch("attributeTagIds");
+  const selectedMoodTags = watch("moodTagIds");
+
+  const toggleTag = (
+    field: "attributeTagIds" | "moodTagIds",
+    tagId: string,
+    currentValue: string[],
+  ) => {
+    if (currentValue.includes(tagId)) {
+      setValue(
+        field,
+        currentValue.filter((id) => id !== tagId),
+      );
+    } else {
+      setValue(field, [...currentValue, tagId]);
+    }
+  };
+
+  const onSubmit = async (data: SpotFormData) => {
+    if (imageUrls.length === 0) {
+      alert("画像を最低1枚アップロードしてください");
+      return;
+    }
+
+    try {
+      const result = await createSpot({
+        variables: {
+          input: {
+            title: data.title,
+            description: data.description || null,
+            address: data.address,
+            categoryId: data.categoryId,
+            priceRange: data.priceRange,
+            businessHours: data.businessHours || null,
+            imageUrls,
+            attributeTagIds: data.attributeTagIds,
+            moodTagIds: data.moodTagIds,
+          },
+        },
+      });
+
+      router.push(`/spots/${result.data?.createSpot.id}`);
+    } catch (error) {
+      console.error("Failed to create spot:", error);
+      alert("スポットの投稿に失敗しました");
+    }
+  };
+
+  if (tagLoading) {
+    return <div className="text-center py-8">読み込み中...</div>;
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="space-y-6 max-w-2xl mx-auto"
+    >
+      <div>
+        <label
+          htmlFor="title"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          スポット名 <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="title"
+          type="text"
+          {...register("title", { required: "スポット名は必須です" })}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+          placeholder="例: 渋谷のおしゃれカフェ"
+        />
+        {errors.title && (
+          <p className="mt-1 text-sm text-red-500">{errors.title.message}</p>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          写真 <span className="text-red-500">*</span>（1〜5枚）
+        </label>
+        <ImageUploader
+          images={imageUrls}
+          onChange={setImageUrls}
+          maxImages={5}
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="address"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          住所 <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="address"
+          type="text"
+          {...register("address", { required: "住所は必須です" })}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+          placeholder="例: 東京都渋谷区〇〇1-2-3"
+        />
+        {errors.address && (
+          <p className="mt-1 text-sm text-red-500">{errors.address.message}</p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="categoryId"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          カテゴリ <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="categoryId"
+          {...register("categoryId", {
+            required: "カテゴリを選択してください",
+          })}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+        >
+          <option value="">選択してください</option>
+          {tagData?.categories.map((category: { id: string; name: string }) => (
+            <option key={category.id} value={category.id}>
+              {category.name}
+            </option>
+          ))}
+        </select>
+        {errors.categoryId && (
+          <p className="mt-1 text-sm text-red-500">
+            {errors.categoryId.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="description"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          説明
+        </label>
+        <textarea
+          id="description"
+          {...register("description")}
+          rows={4}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+          placeholder="このスポットの魅力を教えてください"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="priceRange"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          価格帯
+        </label>
+        <select
+          id="priceRange"
+          {...register("priceRange", { valueAsNumber: true })}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+        >
+          <option value="">選択してください</option>
+          <option value={1}>~1,000円</option>
+          <option value={2}>1,000~3,000円</option>
+          <option value={3}>3,000~5,000円</option>
+          <option value={4}>5,000円~</option>
+        </select>
+      </div>
+
+      <div>
+        <label
+          htmlFor="businessHours"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          営業時間
+        </label>
+        <input
+          id="businessHours"
+          type="text"
+          {...register("businessHours")}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+          placeholder="例: 10:00-22:00（定休日: 月曜）"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          属性タグ（複数選択可）
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {tagData?.attributeTags.map((tag: { id: string; name: string }) => (
+            <button
+              key={tag.id}
+              type="button"
+              onClick={() =>
+                toggleTag("attributeTagIds", tag.id, selectedAttributeTags)
+              }
+              className={`px-3 py-1 rounded-full text-sm transition-colors ${
+                selectedAttributeTags.includes(tag.id)
+                  ? "bg-primary-500 text-white"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+              }`}
+            >
+              {tag.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          ムードタグ（複数選択可）
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {tagData?.moodTags.map((tag: { id: string; name: string }) => (
+            <button
+              key={tag.id}
+              type="button"
+              onClick={() => toggleTag("moodTagIds", tag.id, selectedMoodTags)}
+              className={`px-3 py-1 rounded-full text-sm transition-colors ${
+                selectedMoodTags.includes(tag.id)
+                  ? "bg-primary-500 text-white"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+              }`}
+            >
+              {tag.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="pt-4">
+        <button
+          type="submit"
+          disabled={creating}
+          className="w-full py-3 px-4 bg-primary-500 text-white font-medium rounded-lg hover:bg-primary-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {creating ? "投稿中..." : "スポットを投稿する"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/graphql/mutations/spot.ts
+++ b/frontend/src/graphql/mutations/spot.ts
@@ -1,0 +1,25 @@
+import { gql } from "@apollo/client";
+
+export const CREATE_SPOT = gql`
+  mutation CreateSpot($input: CreateSpotInput!) {
+    createSpot(input: $input) {
+      id
+      title
+    }
+  }
+`;
+
+export const UPDATE_SPOT = gql`
+  mutation UpdateSpot($id: ID!, $input: UpdateSpotInput!) {
+    updateSpot(id: $id, input: $input) {
+      id
+      title
+    }
+  }
+`;
+
+export const DELETE_SPOT = gql`
+  mutation DeleteSpot($id: ID!) {
+    deleteSpot(id: $id)
+  }
+`;

--- a/frontend/src/graphql/queries/tag.ts
+++ b/frontend/src/graphql/queries/tag.ts
@@ -1,0 +1,51 @@
+import { gql } from "@apollo/client";
+
+export const GET_CATEGORIES = gql`
+  query GetCategories {
+    categories {
+      id
+      name
+      slug
+    }
+  }
+`;
+
+export const GET_ATTRIBUTE_TAGS = gql`
+  query GetAttributeTags {
+    attributeTags {
+      id
+      name
+      slug
+    }
+  }
+`;
+
+export const GET_MOOD_TAGS = gql`
+  query GetMoodTags {
+    moodTags {
+      id
+      name
+      slug
+    }
+  }
+`;
+
+export const GET_ALL_TAGS = gql`
+  query GetAllTags {
+    categories {
+      id
+      name
+      slug
+    }
+    attributeTags {
+      id
+      name
+      slug
+    }
+    moodTags {
+      id
+      name
+      slug
+    }
+  }
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -213,7 +213,8 @@
         "graphql": "^16.13.1",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "react-hook-form": "^7.72.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -13547,6 +13548,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
+      "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {


### PR DESCRIPTION
## 概要
以下を実装

- SpotForm コンポーネント（React Hook Form）
- GraphQL mutations: createSpot, updateSpot, deleteSpot
- GraphQL queries: categories, attributeTags, moodTags
- /spots/new ページ
- タグの複数選択UI

UIの質向上は後半にまとめて行う

Closes #51 
Closes #52 
Closes #53 
