### PR TITLE
feat(frontend): スポット詳細画面の作成

### DIFF
--- a/frontend/src/app/(main)/spots/[id]/page.tsx
+++ b/frontend/src/app/(main)/spots/[id]/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useQuery } from "@apollo/client/react";
+import { useParams } from "next/navigation";
+import { GET_SPOT } from "@/graphql/queries/spot";
+import { SpotDetail } from "@/components/spot/SpotDetail";
+
+interface GetSpotResult {
+  spot: {
+    id: string;
+    title: string;
+    description: string | null;
+    address: string;
+    priceRange: number | null;
+    businessHours: string | null;
+    likeCount: number;
+    createdAt: string;
+    images: { id: string; url: string; order: number }[];
+    category: { id: string; name: string };
+    user: { id: string; name: string; avatarUrl: string | null };
+  } | null;
+}
+
+export default function SpotDetailPage() {
+  const params = useParams();
+  const id = params.id as string;
+
+  const { data, loading, error } = useQuery<GetSpotResult>(GET_SPOT, {
+    variables: { id },
+  });
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (error || !data?.spot) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-red-500">スポットが見つかりませんでした</p>
+      </div>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-8 px-4">
+      <SpotDetail spot={data.spot} />
+    </main>
+  );
+}

--- a/frontend/src/components/spot/SpotDetail.tsx
+++ b/frontend/src/components/spot/SpotDetail.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+
+interface SpotImage {
+  id: string;
+  url: string;
+  order: number;
+}
+
+interface SpotDetailProps {
+  spot: {
+    id: string;
+    title: string;
+    description: string | null;
+    address: string;
+    priceRange: number | null;
+    businessHours: string | null;
+    likeCount: number;
+    createdAt: string;
+    images: SpotImage[];
+    category: {
+      id: string;
+      name: string;
+    };
+    user: {
+      id: string;
+      name: string;
+      avatarUrl: string | null;
+    };
+  };
+}
+
+const priceRangeLabels: Record<number, string> = {
+  1: "~1,000円",
+  2: "1,000~3,000円",
+  3: "3,000~5,000円",
+  4: "5,000円~",
+};
+
+export function SpotDetail({ spot }: SpotDetailProps) {
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
+
+  const sortedImages = [...spot.images].sort((a, b) => a.order - b.order);
+  const currentImage = sortedImages[currentImageIndex];
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-6">
+        <div className="aspect-video bg-gray-100 rounded-lg overflow-hidden mb-4">
+          {currentImage && (
+            <img
+              src={currentImage.url}
+              alt={spot.title}
+              className="w-full h-full object-cover"
+            />
+          )}
+        </div>
+
+        {sortedImages.length > 1 && (
+          <div className="flex gap-2 overflow-x-auto pb-2">
+            {sortedImages.map((image, index) => (
+              <button
+                key={image.id}
+                onClick={() => setCurrentImageIndex(index)}
+                className={`flex-shrink-0 w-20 h-20 rounded-lg overflow-hidden border-2 transition-colors ${
+                  index === currentImageIndex
+                    ? "border-primary-500"
+                    : "border-transparent hover:border-gray-300"
+                }`}
+              >
+                <img
+                  src={image.url}
+                  alt={`${spot.title} ${index + 1}`}
+                  className="w-full h-full object-cover"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        <span className="inline-block px-3 py-1 bg-primary-100 text-primary-700 text-sm rounded-full">
+          {spot.category.name}
+        </span>
+
+        <h1 className="text-2xl font-bold text-gray-900">{spot.title}</h1>
+
+        <div className="flex items-center gap-2 text-gray-600">
+          <span>❤️ {spot.likeCount}</span>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <span className="text-gray-500">📍</span>
+          <span className="text-gray-700">{spot.address}</span>
+        </div>
+
+        {spot.priceRange && (
+          <div className="flex items-center gap-2">
+            <span className="text-gray-500">💰</span>
+            <span className="text-gray-700">
+              {priceRangeLabels[spot.priceRange]}
+            </span>
+          </div>
+        )}
+
+        {spot.businessHours && (
+          <div className="flex items-center gap-2">
+            <span className="text-gray-500">🕐</span>
+            <span className="text-gray-700">{spot.businessHours}</span>
+          </div>
+        )}
+
+        {spot.description && (
+          <div className="pt-4 border-t">
+            <p className="text-gray-700 whitespace-pre-wrap">
+              {spot.description}
+            </p>
+          </div>
+        )}
+
+        <div className="pt-4 border-t">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-gray-200 rounded-full overflow-hidden">
+              {spot.user.avatarUrl ? (
+                <img
+                  src={spot.user.avatarUrl}
+                  alt={spot.user.name}
+                  className="w-full h-full object-cover"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-gray-500">
+                  👤
+                </div>
+              )}
+            </div>
+            <div>
+              <p className="font-medium text-gray-900">{spot.user.name}</p>
+              <p className="text-sm text-gray-500">
+                {new Date(spot.createdAt).toLocaleDateString("ja-JP")} に投稿
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/spot/SpotForm.tsx
+++ b/frontend/src/components/spot/SpotForm.tsx
@@ -80,6 +80,13 @@ export function SpotForm() {
     }
   };
 
+  const priceRangeEnumMap: Record<number, string> = {
+    1: "UNDER_1000",
+    2: "RANGE_1000_3000",
+    3: "RANGE_3000_5000",
+    4: "OVER_5000",
+  };
+
   const onSubmit = async (data: SpotFormData) => {
     if (imageUrls.length === 0) {
       alert("画像を最低1枚アップロードしてください");
@@ -94,7 +101,9 @@ export function SpotForm() {
             description: data.description || null,
             address: data.address,
             categoryId: data.categoryId,
-            priceRange: data.priceRange,
+            priceRange: data.priceRange
+              ? priceRangeEnumMap[data.priceRange]
+              : null,
             businessHours: data.businessHours || null,
             imageUrls,
             attributeTagIds: data.attributeTagIds,

--- a/frontend/src/graphql/queries/spot.ts
+++ b/frontend/src/graphql/queries/spot.ts
@@ -1,0 +1,30 @@
+import { gql } from "@apollo/client";
+
+export const GET_SPOT = gql`
+  query GetSpot($id: ID!) {
+    spot(id: $id) {
+      id
+      title
+      description
+      address
+      priceRange
+      businessHours
+      likeCount
+      createdAt
+      images {
+        id
+        url
+        order
+      }
+      category {
+        id
+        name
+      }
+      user {
+        id
+        name
+        avatarUrl
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## 概要
以下の内容を実装

- SpotDetail コンポーネント
- 画像ギャラリー（メイン + サムネイル）
- スポット情報表示（カテゴリ、価格帯、営業時間など）
- 投稿者情報表示
- /spots/[id] ページ

実際にURLにアクセスし、スポット詳細が見れることを確認した

Closes #55 
Closes #56 