### PR TITLE
fix: 画像圧縮処理の追加

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@apollo/client": "^4.1.6",
     "@supabase/supabase-js": "^2.99.2",
+    "browser-image-compression": "^2.0.2",
     "graphql": "^16.13.1",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/frontend/src/components/common/ImageUploader.tsx
+++ b/frontend/src/components/common/ImageUploader.tsx
@@ -2,12 +2,25 @@
 
 import { useState, useCallback } from "react";
 import { uploadImage } from "@/lib/storage";
+import imageCompression from "browser-image-compression";
 
 interface ImageUploaderProps {
   images: string[];
   onChange: (images: string[]) => void;
   maxImages?: number;
 }
+
+const compressImage = async (file: File): Promise<File> => {
+  if (file.type === "image/gif") return file;
+
+  const options = {
+    maxSizeMB: 1,
+    maxWidthOrHeight: 1920,
+    useWebWorker: true,
+  };
+
+  return imageCompression(file, options);
+};
 
 export function ImageUploader({
   images,
@@ -34,7 +47,10 @@ export function ImageUploader({
       setError(null);
 
       try {
-        const uploadPromises = filesToUpload.map((file) => uploadImage(file));
+        const uploadPromises = filesToUpload.map(async (file) => {
+          const compressed = await compressImage(file);
+          return uploadImage(compressed);
+        });
         const newUrls = await Promise.all(uploadPromises);
 
         onChange([...images, ...newUrls]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -211,6 +211,7 @@
       "dependencies": {
         "@apollo/client": "^4.1.6",
         "@supabase/supabase-js": "^2.99.2",
+        "browser-image-compression": "^2.0.2",
         "graphql": "^16.13.1",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -6928,6 +6929,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -15617,6 +15627,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",


### PR DESCRIPTION
## 概要

iPhoneで撮影した写真が5MB制限を超えて投稿できない問題に対応した。
`browser-image-compression` を使い、Supabaseへのアップロード前にブラウザ側で画像を圧縮する処理を追加している。

## 背景

iPhoneカメラは高解像度で撮影するため、HEIC→JPEG変換後も4〜8MBになるケースが多い。
クライアント側に圧縮処理がなかったことが根本原因。

## 変更内容

- `browser-image-compression` をインストール
- `ImageUploader.tsx` に `compressImage` 関数を追加
- `handleFileSelect` 内で `uploadImage` 呼び出し前に圧縮を挟む

## 変更しなかった箇所

`storage.ts` の `uploadImage` は変更していない。
圧縮責務をコンポーネント側に閉じることで、アップロード関数の単一責任を維持している。

## 圧縮設定

| オプション | 値 | 理由 |
|---|---|---|
| maxSizeMB | 1 | ストレージコストと画質のバランス |
| maxWidthOrHeight | 1920 | フルHD相当、表示用途では十分 |
| useWebWorker | true | メインスレッドのブロッキングを防ぐ |

GIFはアニメーション破損を防ぐため圧縮対象から除外している。

## 動作確認

- [ ] iPhoneで撮影した写真（5MB超）が投稿できることを確認
- [ ] 複数枚同時アップロードが正常に動作することを確認
- [ ] GIFがそのままアップロードされることを確認
- [ ] アップロード中のUI（ローディング表示）が固まらないことを確認

## 関連

Closes #62 
Closes #69 