### PR TITLE
feat(frontend): 無限スクロールの実装

### DIFF
--- a/frontend/src/app/(main)/spots/page.tsx
+++ b/frontend/src/app/(main)/spots/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@apollo/client/react";
+import { useCallback, useState } from "react";
 import { GET_SPOTS } from "@/graphql/queries/spot";
 import { SpotList } from "@/components/spot/SpotList";
 import Link from "next/link";
@@ -10,10 +11,44 @@ import type { GetSpotsResponse, GetSpotsVariables } from "@/graphql/types/spot";
 export default function SpotsPage() {
   const { user } = useAuth();
 
-  const { data, loading, error } = useQuery<
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const { data, loading, error, fetchMore } = useQuery<
     GetSpotsResponse,
     GetSpotsVariables
-  >(GET_SPOTS, { variables: { first: 20 } });
+  >(GET_SPOTS, { variables: { first: 2 } });
+
+  const handleLoadMore = useCallback(async () => {
+    if (!data?.spots?.pageInfo?.endCursor) return;
+
+    setLoadingMore(true);
+
+    try {
+      await fetchMore({
+        variables: {
+          first: 20,
+          after: data.spots.pageInfo.endCursor,
+        },
+        updateQuery: (prevResult, { fetchMoreResult }) => {
+          if (!fetchMoreResult) return prevResult;
+
+          return {
+            spots: {
+              ...fetchMoreResult.spots,
+              edges: [
+                ...prevResult.spots.edges,
+                ...fetchMoreResult.spots.edges,
+              ],
+            },
+          };
+        },
+      });
+    } catch (err) {
+      console.error("Failed to load more:", err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [data, fetchMore]);
 
   if (error) {
     return (
@@ -24,6 +59,7 @@ export default function SpotsPage() {
   }
 
   const spots = data?.spots?.edges?.map((edge) => edge.node) ?? [];
+  const hasNextPage = data?.spots?.pageInfo?.hasNextPage ?? false;
 
   return (
     <main className="min-h-screen bg-gray-50">
@@ -52,7 +88,13 @@ export default function SpotsPage() {
       </div>
 
       <div className="max-w-7xl mx-auto px-4 py-8">
-        <SpotList spots={spots} loading={loading} />
+        <SpotList
+          spots={spots}
+          loading={loading}
+          hasNextPage={hasNextPage}
+          loadingMore={loadingMore}
+          onLoadMore={handleLoadMore}
+        />
       </div>
     </main>
   );

--- a/frontend/src/components/spot/SpotList.tsx
+++ b/frontend/src/components/spot/SpotList.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect } from "react";
 import { SpotCard } from "./SpotCard";
+import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 
 interface SpotListProps {
   spots: Array<{
@@ -13,9 +15,30 @@ interface SpotListProps {
     user: { name: string; avatarUrl: string | null };
   }>;
   loading?: boolean;
+  hasNextPage?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?: () => void;
 }
 
-export function SpotList({ spots, loading = false }: SpotListProps) {
+export function SpotList({
+  spots,
+  loading = false,
+  hasNextPage = false,
+  loadingMore = false,
+  onLoadMore,
+}: SpotListProps) {
+  const { targetRef, isIntersecting } = useIntersectionObserver<HTMLDivElement>(
+    {
+      enabled: hasNextPage && !loadingMore,
+    },
+  );
+
+  useEffect(() => {
+    if (isIntersecting && hasNextPage && !loadingMore && onLoadMore) {
+      onLoadMore();
+    }
+  }, [isIntersecting, hasNextPage, loadingMore, onLoadMore]);
+
   if (loading) {
     return (
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
@@ -35,11 +58,43 @@ export function SpotList({ spots, loading = false }: SpotListProps) {
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-      {spots.map((spot) => (
-        <SpotCard key={spot.id} spot={spot} />
-      ))}
-    </div>
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        {spots.map((spot) => (
+          <SpotCard key={spot.id} spot={spot} />
+        ))}
+      </div>
+
+      {loadingMore && (
+        <div className="flex justify-center py-8">
+          <div className="flex items-center gap-2 text-gray-500">
+            <svg
+              className="animate-spin h-5 w-5"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            <span>読み込み中...</span>
+          </div>
+        </div>
+      )}
+
+      {hasNextPage && <div ref={targetRef} className="h-1" />}
+    </>
   );
 }
 

--- a/frontend/src/hooks/useIntersectionObserver.ts
+++ b/frontend/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseIntersectionObserverOptions {
+  // どのくらい手前で発火するか（0.0〜1.0）
+  threshold?: number;
+  // ルート要素からのマージン
+  rootMargin?: string;
+  // 監視を有効にするかどうか
+  enabled?: boolean;
+}
+
+/**
+ * Intersection Observer を使って要素が画面内に入ったかを検知するフック
+ */
+export function useIntersectionObserver<T extends HTMLElement>({
+  threshold = 0,
+  rootMargin = "100px",
+  enabled = true,
+}: UseIntersectionObserverOptions = {}) {
+  const targetRef = useRef<T>(null);
+  const [isIntersecting, setIsIntersecting] = useState(false);
+
+  useEffect(() => {
+    const target = targetRef.current;
+
+    if (!target || !enabled) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        setIsIntersecting(entries[0].isIntersecting);
+      },
+      {
+        threshold,
+        rootMargin,
+      },
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [threshold, rootMargin, enabled]);
+
+  return { targetRef, isIntersecting };
+}


### PR DESCRIPTION
## 概要
無限スクロールによるスポット一覧のページネーションを実装した。

## 変更内容

### Frontend
- `useIntersectionObserver` カスタムフックを作成
- `SpotList` に無限スクロール機能を追加
- `SpotsPage` に `fetchMore` によるページネーションを追加
- 追加読み込み中のローディングインジケーターを追加


## 動作確認
- [ ] スクロールで次のページが自動的に読み込まれる
- [ ] 読み込み中にスピナーが表示される
- [ ] 全件読み込み後は追加読み込みが発生しない

Closes #71 
Closes #72 
Closes #73 
Closes #74 
Closes #75 