### PR TITLE
fix(frontend): 画像圧縮オプション強化とサイズ検証の追加

### DIFF
--- a/frontend/src/components/common/ImageUploader.tsx
+++ b/frontend/src/components/common/ImageUploader.tsx
@@ -10,16 +10,25 @@ interface ImageUploaderProps {
   maxImages?: number;
 }
 
+const MAX_FILE_SIZE_MB = 4.5;
+
 const compressImage = async (file: File): Promise<File> => {
   if (file.type === "image/gif") return file;
 
   const options = {
     maxSizeMB: 1,
-    maxWidthOrHeight: 1920,
+    maxWidthOrHeight: 1280,
+    initialQuality: 0.8,
     useWebWorker: true,
   };
 
-  return imageCompression(file, options);
+  const compressed = await imageCompression(file, options);
+
+  if (compressed.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+    throw new Error("画像サイズが大きすぎます。別の画像をお試しください。");
+  }
+
+  return compressed;
 };
 
 export function ImageUploader({


### PR DESCRIPTION
## 関連Issue
Closes #86

## 変更の背景
iPhone高画質写真（特に最近の機種）をアップロードすると、圧縮処理後もサイズ制限に引っかかりエラーになっていた。`browser-image-compression` の `maxSizeMB` はベストエフォートであり、元ファイルが大きすぎる場合に目標サイズを下回れないことがある。また圧縮後のサイズ検証がなかったため、制限超えのままSupabaseに送信されていた。

## 変更内容
- `maxWidthOrHeight` を `1920` → `1280` に変更し圧縮効果を強化
- `initialQuality: 0.8` を追加
- 圧縮後に4.5MBを超えていた場合、ユーザー向けエラーメッセージを表示

## 変更の種類
- [x] バグ修正

## 動作確認
- [ ] ローカルで動作確認済み

## 迷った点・今後の課題
- `MAX_FILE_SIZE_MB: 4.5` はSupabaseバケットの制限値に合わせて要調整