### PR TITLE
feat(frontend): 絵文字を Lucide React アイコンに置き換え

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@supabase/supabase-js": "^2.99.2",
     "browser-image-compression": "^2.0.2",
     "graphql": "^16.13.1",
+    "lucide-react": "^1.8.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/frontend/src/components/spot/SpotCard.tsx
+++ b/frontend/src/components/spot/SpotCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { Heart, MapPin, UserCircle } from "lucide-react";
 
 interface SpotCardProps {
   spot: {
@@ -41,7 +42,7 @@ export function SpotCard({ spot }: SpotCardProps) {
               {spot.category.name}
             </span>
             <span className="text-sm text-gray-500 flex items-center gap-1">
-              <span>❤️</span>
+              <Heart size={14} className="text-rose-400" />
               <span>{spot.likeCount}</span>
             </span>
           </div>
@@ -50,8 +51,8 @@ export function SpotCard({ spot }: SpotCardProps) {
             {spot.title}
           </h3>
 
-          <p className="text-sm text-gray-500 line-clamp-1">
-            <span className="mr-1">📍</span>
+          <p className="text-sm text-gray-500 line-clamp-1 flex items-center gap-1">
+            <MapPin size={13} className="flex-shrink-0" />
             {spot.address}
           </p>
 
@@ -64,8 +65,8 @@ export function SpotCard({ spot }: SpotCardProps) {
                   className="w-full h-full object-cover"
                 />
               ) : (
-                <div className="w-full h-full flex items-center justify-center text-gray-400 text-xs">
-                  👤
+                <div className="w-full h-full flex items-center justify-center text-gray-400">
+                  <UserCircle size={24} />
                 </div>
               )}
             </div>

--- a/frontend/src/components/spot/SpotDetail.tsx
+++ b/frontend/src/components/spot/SpotDetail.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import { Heart, MapPin, Banknote, Clock, UserCircle } from "lucide-react";
 
 interface SpotImage {
   id: string;
@@ -95,18 +96,19 @@ export function SpotDetail({ spot }: SpotDetailProps) {
 
         <h1 className="text-2xl font-bold text-gray-900">{spot.title}</h1>
 
-        <div className="flex items-center gap-2 text-gray-600">
-          <span>❤️ {spot.likeCount}</span>
+        <div className="flex items-center gap-1.5 text-gray-600">
+          <Heart size={16} className="text-rose-400" />
+          <span>{spot.likeCount}</span>
         </div>
 
-        <div className="flex items-start gap-2">
-          <span className="text-gray-500">📍</span>
+        <div className="flex items-start gap-1.5">
+          <MapPin size={16} className="text-gray-400 flex-shrink-0 mt-0.5" />
           <span className="text-gray-700">{spot.address}</span>
         </div>
 
         {spot.priceRange && (
-          <div className="flex items-center gap-2">
-            <span className="text-gray-500">💰</span>
+          <div className="flex items-center gap-1.5">
+            <Banknote size={16} className="text-gray-400 flex-shrink-0" />
             <span className="text-gray-700">
               {priceRangeLabels[spot.priceRange]}
             </span>
@@ -114,8 +116,8 @@ export function SpotDetail({ spot }: SpotDetailProps) {
         )}
 
         {spot.businessHours && (
-          <div className="flex items-center gap-2">
-            <span className="text-gray-500">🕐</span>
+          <div className="flex items-center gap-1.5">
+            <Clock size={16} className="text-gray-400 flex-shrink-0" />
             <span className="text-gray-700">{spot.businessHours}</span>
           </div>
         )}
@@ -138,8 +140,8 @@ export function SpotDetail({ spot }: SpotDetailProps) {
                   className="w-full h-full object-cover"
                 />
               ) : (
-                <div className="w-full h-full flex items-center justify-center text-gray-500">
-                  👤
+                <div className="w-full h-full flex items-center justify-center text-gray-400">
+                  <UserCircle size={40} />
                 </div>
               )}
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,6 +216,7 @@
         "@supabase/supabase-js": "^2.99.2",
         "browser-image-compression": "^2.0.2",
         "graphql": "^16.13.1",
+        "lucide-react": "^1.8.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -12121,6 +12122,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {


### PR DESCRIPTION
## 関連Issue
Closes #88
Closes #90 

## 変更の背景
SpotCard・SpotDetail で絵文字をUIアイコンとして使用していたが、チープな見た目になっていたため Lucide React に置き換えた。

## 変更内容
- `lucide-react` をインストール
- SpotCard: ❤️ → `<Heart />`, 📍 → `<MapPin />`, 👤 → `<UserCircle />`
- SpotDetail: ❤️ → `<Heart />`, 📍 → `<MapPin />`, 💰 → `<Banknote />`, 🕐 → `<Clock />`, 👤 → `<UserCircle />`

## 変更の種類
- [x] 新機能

## 動作確認
- [ ] ローカルで動作確認済み

## 迷った点・今後の課題
Phase 1-C で追加するいいねボタン等も同じライブラリで統一する