### PR TITLE
feat(backend): SpotFilterInput の実装と動的 where 構築

### DIFF
--- a/backend/src/spot/dto/spot-filter.input.ts
+++ b/backend/src/spot/dto/spot-filter.input.ts
@@ -1,31 +1,19 @@
-import { InputType, Field, registerEnumType } from '@nestjs/graphql';
-
-export enum SpotSortBy {
-  LIKE_COUNT = 'likeCount',
-  CREATED_AT = 'createdAt',
-  TITLE = 'title',
-}
-
-registerEnumType(SpotSortBy, {
-  name: 'SpotSortBy',
-  description: 'スポットのソート対象',
-});
-
-export enum SortOrder {
-  ASC = 'asc',
-  DESC = 'desc',
-}
-
-registerEnumType(SortOrder, {
-  name: 'SortOrder',
-  description: 'ソート順序',
-});
+import { InputType, Field, ID } from '@nestjs/graphql';
 
 @InputType()
-export class SpotSortInput {
-  @Field(() => SpotSortBy, { defaultValue: SpotSortBy.CREATED_AT })
-  sortBy: SpotSortBy;
+export class SpotFilterInput {
+  @Field(() => ID, { nullable: true })
+  categoryId?: string;
 
-  @Field(() => SortOrder, { defaultValue: SortOrder.DESC })
-  order: SortOrder;
+  @Field(() => [ID], { nullable: true })
+  attributeTagIds?: string[];
+
+  @Field(() => [ID], { nullable: true })
+  moodTagIds?: string[];
+
+  @Field(() => String, { nullable: true })
+  tagSearchMode?: 'AND' | 'OR';
+
+  @Field(() => String, { nullable: true })
+  keyword?: string;
 }

--- a/backend/src/spot/dto/spot-sort.input.ts
+++ b/backend/src/spot/dto/spot-sort.input.ts
@@ -1,0 +1,31 @@
+import { InputType, Field, registerEnumType } from '@nestjs/graphql';
+
+export enum SpotSortBy {
+  LIKE_COUNT = 'likeCount',
+  CREATED_AT = 'createdAt',
+  TITLE = 'title',
+}
+
+registerEnumType(SpotSortBy, {
+  name: 'SpotSortBy',
+  description: 'スポットのソート対象',
+});
+
+export enum SortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+registerEnumType(SortOrder, {
+  name: 'SortOrder',
+  description: 'ソート順序',
+});
+
+@InputType()
+export class SpotSortInput {
+  @Field(() => SpotSortBy, { defaultValue: SpotSortBy.CREATED_AT })
+  sortBy: SpotSortBy;
+
+  @Field(() => SortOrder, { defaultValue: SortOrder.DESC })
+  order: SortOrder;
+}

--- a/backend/src/spot/spot.resolver.ts
+++ b/backend/src/spot/spot.resolver.ts
@@ -22,7 +22,8 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { AuthUser } from 'src/auth/types/auth-user.type';
 import { SpotLoader } from './spot.loader';
 import { SpotConnection } from './dto/spot-connection.object';
-import { SpotSortInput } from './dto/spot-filter.input';
+import { SpotSortInput } from './dto/spot-sort.input';
+import { SpotFilterInput } from './dto/spot-filter.input';
 
 @Resolver(() => Spot)
 export class SpotResolver {
@@ -56,8 +57,10 @@ export class SpotResolver {
     @Args('after', { type: () => String, nullable: true }) after?: string,
     @Args('sort', { type: () => SpotSortInput, nullable: true })
     sort?: SpotSortInput,
+    @Args('filter', { type: () => SpotFilterInput, nullable: true })
+    filter?: SpotFilterInput,
   ): Promise<SpotConnection> {
-    return this.spotService.findMany(first, after, sort);
+    return this.spotService.findMany(first, after, sort, filter);
   }
 
   @Mutation(() => Spot)

--- a/backend/src/spot/spot.service.ts
+++ b/backend/src/spot/spot.service.ts
@@ -4,9 +4,11 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
 import { CreateSpotInput } from './dto/create-spot.input';
 import { UpdateSpotInput } from './dto/update-spot.input';
-import { SpotSortBy, SortOrder, SpotSortInput } from './dto/spot-filter.input';
+import { SpotSortBy, SortOrder, SpotSortInput } from './dto/spot-sort.input';
+import { SpotFilterInput } from './dto/spot-filter.input';
 import {
   SpotConnection,
   SpotEdge,
@@ -162,19 +164,25 @@ export class SpotService {
     first: number = 20,
     after?: string,
     sort?: SpotSortInput,
+    filter?: SpotFilterInput,
   ): Promise<SpotConnection> {
     const sortBy = sort?.sortBy ?? SpotSortBy.CREATED_AT;
     const order = sort?.order ?? SortOrder.DESC;
 
     const orderBy = this.buildOrderBy(sortBy, order);
+    const filterWhere = this.buildWhereClause(filter);
     const cursorCondition = after
       ? this.buildCursorCondition(after, sortBy, order)
-      : {};
+      : null;
+
+    const where: Prisma.SpotWhereInput = cursorCondition
+      ? { AND: [filterWhere, cursorCondition] }
+      : filterWhere;
 
     const take = first + 1;
 
     const spots = await this.prisma.spot.findMany({
-      where: cursorCondition,
+      where,
       take,
       orderBy,
       include: {
@@ -193,7 +201,7 @@ export class SpotService {
       cursor: this.encodeCursor(spot, sortBy),
     }));
 
-    const totalCount = await this.prisma.spot.count();
+    const totalCount = await this.prisma.spot.count({ where: filterWhere });
 
     const pageInfo: PageInfo = {
       hasNextPage,
@@ -207,6 +215,37 @@ export class SpotService {
       pageInfo,
       totalCount,
     };
+  }
+
+  private buildWhereClause(filter?: SpotFilterInput): Prisma.SpotWhereInput {
+    if (!filter) return {};
+
+    const where: Prisma.SpotWhereInput = {};
+
+    if (filter.categoryId) {
+      where.categoryId = filter.categoryId;
+    }
+
+    if (filter.attributeTagIds && filter.attributeTagIds.length > 0) {
+      where.attributeTags = {
+        some: { tagId: { in: filter.attributeTagIds } },
+      };
+    }
+
+    if (filter.moodTagIds && filter.moodTagIds.length > 0) {
+      where.moodTags = {
+        some: { tagId: { in: filter.moodTagIds } },
+      };
+    }
+
+    if (filter.keyword) {
+      where.OR = [
+        { title: { contains: filter.keyword, mode: 'insensitive' } },
+        { description: { contains: filter.keyword, mode: 'insensitive' } },
+      ];
+    }
+
+    return where;
   }
 
   /**


### PR DESCRIPTION
## 関連Issue
Closes #95
Closes #97 
Closes #98 

## 変更の背景
Phase 1-C の検索機能実装の第一歩として、バックエンドにフィルター引数を追加する必要があった。

## 変更内容
- `SpotSortInput` を `spot-sort.input.ts` に分離（ファイル名と内容の乖離を解消）
- `SpotFilterInput` DTO を新規作成（`categoryId`, `attributeTagIds`, `moodTagIds`, `keyword`, `tagSearchMode`）
- `buildWhereClause` でフィルター条件から Prisma `where` を動的に構築
- `filterWhere` と `cursorCondition` を `AND` でラップし、キーワード検索とカーソルの `OR` キー衝突を防止
- `totalCount` はカーソル条件を除いた `filterWhere` のみで集計
- `SpotResolver` の `spots` クエリに `filter` 引数を追加

## 変更の種類
- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他:

## 動作確認
- [x] ローカルで動作確認済み

## 迷った点・今後の課題
- `filterWhere` と `cursorCondition` の合成は単純なスプレッドだと `OR` キーが衝突するため `AND` ラップで対処した
- `tagSearchMode` は現状 `String` 型の仮置き。Day 2 で `TagSearchMode` Enum に置き換える