### PR TITLE
feat(backend): AND/OR 検索モードの実装

### DIFF
--- a/backend/src/spot/dto/spot-filter.input.ts
+++ b/backend/src/spot/dto/spot-filter.input.ts
@@ -1,4 +1,5 @@
 import { InputType, Field, ID } from '@nestjs/graphql';
+import { TagSearchMode } from './tag-search-mode.enum';
 
 @InputType()
 export class SpotFilterInput {
@@ -11,8 +12,8 @@ export class SpotFilterInput {
   @Field(() => [ID], { nullable: true })
   moodTagIds?: string[];
 
-  @Field(() => String, { nullable: true })
-  tagSearchMode?: 'AND' | 'OR';
+  @Field(() => TagSearchMode, { nullable: true, defaultValue: TagSearchMode.OR })
+  tagSearchMode?: TagSearchMode;
 
   @Field(() => String, { nullable: true })
   keyword?: string;

--- a/backend/src/spot/dto/spot-filter.input.ts
+++ b/backend/src/spot/dto/spot-filter.input.ts
@@ -12,7 +12,10 @@ export class SpotFilterInput {
   @Field(() => [ID], { nullable: true })
   moodTagIds?: string[];
 
-  @Field(() => TagSearchMode, { nullable: true, defaultValue: TagSearchMode.OR })
+  @Field(() => TagSearchMode, {
+    nullable: true,
+    defaultValue: TagSearchMode.OR,
+  })
   tagSearchMode?: TagSearchMode;
 
   @Field(() => String, { nullable: true })

--- a/backend/src/spot/dto/tag-search-mode.enum.ts
+++ b/backend/src/spot/dto/tag-search-mode.enum.ts
@@ -1,0 +1,15 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum TagSearchMode {
+  AND = 'AND',
+  OR = 'OR',
+}
+
+registerEnumType(TagSearchMode, {
+  name: 'TagSearchMode',
+  description: 'タグ検索モード: AND=全タグ一致, OR=いずれか一致',
+  valuesMap: {
+    AND: { description: 'すべてのタグを含むスポットを返す' },
+    OR: { description: 'いずれかのタグを含むスポットを返す' },
+  },
+});

--- a/backend/src/spot/spot.service.ts
+++ b/backend/src/spot/spot.service.ts
@@ -9,6 +9,7 @@ import { CreateSpotInput } from './dto/create-spot.input';
 import { UpdateSpotInput } from './dto/update-spot.input';
 import { SpotSortBy, SortOrder, SpotSortInput } from './dto/spot-sort.input';
 import { SpotFilterInput } from './dto/spot-filter.input';
+import { TagSearchMode } from './dto/tag-search-mode.enum';
 import {
   SpotConnection,
   SpotEdge,
@@ -226,16 +227,32 @@ export class SpotService {
       where.categoryId = filter.categoryId;
     }
 
+    const mode = filter.tagSearchMode ?? TagSearchMode.OR;
+
     if (filter.attributeTagIds && filter.attributeTagIds.length > 0) {
-      where.attributeTags = {
-        some: { tagId: { in: filter.attributeTagIds } },
-      };
+      if (mode === TagSearchMode.AND) {
+        const conditions = filter.attributeTagIds.map((tagId) => ({
+          attributeTags: { some: { tagId } },
+        }));
+        where.AND = [...((where.AND as object[]) ?? []), ...conditions];
+      } else {
+        where.attributeTags = {
+          some: { tagId: { in: filter.attributeTagIds } },
+        };
+      }
     }
 
     if (filter.moodTagIds && filter.moodTagIds.length > 0) {
-      where.moodTags = {
-        some: { tagId: { in: filter.moodTagIds } },
-      };
+      if (mode === TagSearchMode.AND) {
+        const conditions = filter.moodTagIds.map((tagId) => ({
+          moodTags: { some: { tagId } },
+        }));
+        where.AND = [...((where.AND as object[]) ?? []), ...conditions];
+      } else {
+        where.moodTags = {
+          some: { tagId: { in: filter.moodTagIds } },
+        };
+      }
     }
 
     if (filter.keyword) {


### PR DESCRIPTION
## 関連Issue
Closes #99
Closes #101 

## 変更の背景
Day 1 で `tagSearchMode` を `String` 型の仮置きとして実装していた。正式な Enum として GraphQL スキーマに公開し、AND/OR 分岐ロジックを有効化する必要があった。

## 変更内容
- `TagSearchMode` Enum を新規作成し GraphQL スキーマに登録
- `SpotFilterInput` の `tagSearchMode` を `String` 型から `TagSearchMode` Enum に変更
- `buildWhereClause` に AND/OR 分岐を追加
  - AND: タグ数分の `some` 条件を `where.AND` に追記
  - OR: `some + in` で一括マッチ（既存の挙動）

## 変更の種類
- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他:

## 動作確認
- [ ] ローカルで動作確認済み

## 迷った点・今後の課題
- `where.AND` への追記はスプレッドで行っている。属性タグとムードタグ両方が AND モードの場合、1回目の代入が2回目で上書きされるのを防ぐため `[...既存, ...新規条件]` のパターンを採用した