### PR TITLE
feat: キーワード検索の実装

### DIFF
--- a/backend/src/spot/spot.service.ts
+++ b/backend/src/spot/spot.service.ts
@@ -256,10 +256,13 @@ export class SpotService {
     }
 
     if (filter.keyword) {
-      where.OR = [
-        { title: { contains: filter.keyword, mode: 'insensitive' } },
-        { description: { contains: filter.keyword, mode: 'insensitive' } },
-      ];
+      const keywordCondition: Prisma.SpotWhereInput = {
+        OR: [
+          { title: { contains: filter.keyword, mode: 'insensitive' } },
+          { description: { contains: filter.keyword, mode: 'insensitive' } },
+        ],
+      };
+      where.AND = [...((where.AND as object[]) ?? []), keywordCondition];
     }
 
     return where;

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSpotFilter } from '@/hooks/useSpotFilter';
+import { useDebounce } from '@/hooks/useDebounce';
+
+export function SearchBar() {
+  const { currentFilter, updateFilter } = useSpotFilter();
+  const [inputValue, setInputValue] = useState(currentFilter.keyword ?? '');
+  const debouncedValue = useDebounce(inputValue, 500);
+
+  useEffect(() => {
+    if (debouncedValue === (currentFilter.keyword ?? '')) return;
+    updateFilter({ keyword: debouncedValue || undefined });
+  }, [debouncedValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    setInputValue(currentFilter.keyword ?? '');
+  }, [currentFilter.keyword]);
+
+  return (
+    <div className="relative">
+      <div className="absolute inset-y-0 left-3 flex items-center pointer-events-none">
+        <svg
+          className="h-4 w-4 text-gray-400"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+      </div>
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        placeholder="スポット名・キーワードで検索"
+        className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-400 text-sm"
+      />
+      {inputValue && (
+        <button
+          onClick={() => {
+            setInputValue('');
+            updateFilter({ keyword: undefined });
+          }}
+          className="absolute inset-y-0 right-3 flex items-center text-gray-400 hover:text-gray-600"
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -15,6 +15,7 @@ export function SearchBar() {
   }, [debouncedValue]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setInputValue(currentFilter.keyword ?? '');
   }, [currentFilter.keyword]);
 

--- a/frontend/src/components/spot/SpotsPageContent.tsx
+++ b/frontend/src/components/spot/SpotsPageContent.tsx
@@ -10,6 +10,7 @@ import type { GetSpotsQuery, GetSpotsQueryVariables } from "@/graphql/generated/
 import { SpotSortBy, SortOrder, TagSearchMode } from "@/graphql/generated/graphql";
 import { SortSelect, SortOption } from "@/components/search/SortSelect";
 import { FilterPanel } from "@/components/search/FilterPanel";
+import { SearchBar } from "@/components/search/SearchBar";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSpotFilter } from "@/hooks/useSpotFilter";
 
@@ -172,6 +173,9 @@ export default function SpotsPageContent() {
             <FilterPanel />
           </aside>
           <div className="flex-1 min-w-0">
+            <div className="mb-4">
+              <SearchBar />
+            </div>
             <SpotList
               spots={spots}
               loading={loading}

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## 関連Issue
Closes #106
Closes #108

## 変更の背景
スポット名・説明文によるキーワード検索ができなかった。

## 変更内容
- buildWhereClause の keyword 処理を `where.AND` に統合（タグ OR との競合解消）
- `useDebounce` フック：500ms デバウンス処理
- `SearchBar` コンポーネント：入力・デバウンス・URL 反映・クリアボタン
- `SpotsPageContent` に SearchBar を統合

## 変更の種類
- [x] 新機能

## 動作確認
- [x] ローカルで動作確認済み

## 迷った点・今後の課題
- keyword の OR をトップレベルに置くとタグ OR 条件と干渉するため AND で包む設計を採用