### PR TITLE
feat(backend): LikeModule の実装

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { CategoryModule } from './category/category.module';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { SpotModule } from './spot/spot.module';
+import { LikeModule } from './like/like.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { SpotModule } from './spot/spot.module';
     AuthModule,
     UserModule,
     SpotModule,
+    LikeModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/auth.guard.ts
+++ b/backend/src/auth/auth.guard.ts
@@ -9,3 +9,15 @@ export class GqlAuthGuard extends AuthGuard('jwt') {
     return ctx.getContext().req;
   }
 }
+
+@Injectable()
+export class OptionalGqlAuthGuard extends AuthGuard('jwt') {
+  getRequest(context: ExecutionContext) {
+    const ctx = GqlExecutionContext.create(context);
+    return ctx.getContext().req;
+  }
+
+  handleRequest(_err: any, user: any) {
+    return user || null;
+  }
+}

--- a/backend/src/like/dto/like-result.object.ts
+++ b/backend/src/like/dto/like-result.object.ts
@@ -1,0 +1,10 @@
+import { ObjectType, Field, Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class LikeResult {
+  @Field()
+  liked: boolean;
+
+  @Field(() => Int)
+  likeCount: number;
+}

--- a/backend/src/like/like.loader.ts
+++ b/backend/src/like/like.loader.ts
@@ -1,0 +1,34 @@
+import { Injectable, Scope } from '@nestjs/common';
+import DataLoader from 'dataloader';
+import { PrismaService } from '../../prisma/prisma.service';
+
+@Injectable({ scope: Scope.REQUEST })
+export class LikeLoader {
+  constructor(private prisma: PrismaService) {}
+
+  // key format: "${supabaseId}:${spotId}"
+  readonly isLikedLoader = new DataLoader<string, boolean>(async (keys) => {
+    const pairs = keys.map((k) => {
+      const idx = k.indexOf(':');
+      return { supabaseId: k.slice(0, idx), spotId: k.slice(idx + 1) };
+    });
+
+    const supabaseId = pairs[0].supabaseId;
+    const spotIds = pairs.map((p) => p.spotId);
+
+    const user = await this.prisma.user.findUnique({
+      where: { supabaseId },
+      select: { id: true },
+    });
+
+    if (!user) return keys.map(() => false);
+
+    const likes = await this.prisma.like.findMany({
+      where: { userId: user.id, spotId: { in: spotIds } },
+      select: { spotId: true },
+    });
+
+    const likedSet = new Set(likes.map((l) => l.spotId));
+    return pairs.map((p) => likedSet.has(p.spotId));
+  });
+}

--- a/backend/src/like/like.module.ts
+++ b/backend/src/like/like.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { LikeService } from './like.service';
+import { LikeResolver } from './like.resolver';
+import { LikeLoader } from './like.loader';
+import { UserModule } from '../user/user.module';
+
+@Module({
+  imports: [UserModule],
+  providers: [LikeResolver, LikeService, LikeLoader],
+  exports: [LikeLoader, LikeService],
+})
+export class LikeModule {}

--- a/backend/src/like/like.resolver.ts
+++ b/backend/src/like/like.resolver.ts
@@ -1,0 +1,26 @@
+import { Resolver, Mutation, Args, ID } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { LikeService } from './like.service';
+import { LikeResult } from './dto/like-result.object';
+import { UserService } from '../user/user.service';
+import { GqlAuthGuard } from '../auth/auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { AuthUser } from '../auth/types/auth-user.type';
+
+@Resolver()
+export class LikeResolver {
+  constructor(
+    private likeService: LikeService,
+    private userService: UserService,
+  ) {}
+
+  @Mutation(() => LikeResult)
+  @UseGuards(GqlAuthGuard)
+  async toggleLike(
+    @Args('spotId', { type: () => ID }) spotId: string,
+    @CurrentUser() authUser: AuthUser,
+  ): Promise<LikeResult> {
+    const user = await this.userService.getOrCreateUser(authUser);
+    return this.likeService.toggleLike(user.id, spotId);
+  }
+}

--- a/backend/src/like/like.service.ts
+++ b/backend/src/like/like.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { LikeResult } from './dto/like-result.object';
+
+@Injectable()
+export class LikeService {
+  constructor(private prisma: PrismaService) {}
+
+  async toggleLike(userId: string, spotId: string): Promise<LikeResult> {
+    const spot = await this.prisma.spot.findUnique({
+      where: { id: spotId },
+      select: { id: true, likeCount: true },
+    });
+
+    if (!spot) {
+      throw new NotFoundException(`Spot with id ${spotId} not found`);
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const existingLike = await tx.like.findUnique({
+        where: { userId_spotId: { userId, spotId } },
+      });
+
+      if (existingLike) {
+        await tx.like.delete({ where: { id: existingLike.id } });
+        const updated = await tx.spot.update({
+          where: { id: spotId },
+          data: { likeCount: { decrement: 1 } },
+          select: { likeCount: true },
+        });
+        return { liked: false, likeCount: Math.max(0, updated.likeCount) };
+      }
+
+      await tx.like.create({ data: { userId, spotId } });
+      const updated = await tx.spot.update({
+        where: { id: spotId },
+        data: { likeCount: { increment: 1 } },
+        select: { likeCount: true },
+      });
+      return { liked: true, likeCount: updated.likeCount };
+    });
+  }
+
+  async isLiked(userId: string, spotId: string): Promise<boolean> {
+    const like = await this.prisma.like.findUnique({
+      where: { userId_spotId: { userId, spotId } },
+      select: { id: true },
+    });
+    return like !== null;
+  }
+
+  async getLikedSpotIdsByUser(userId: string): Promise<string[]> {
+    const likes = await this.prisma.like.findMany({
+      where: { userId },
+      select: { spotId: true },
+    });
+    return likes.map((l) => l.spotId);
+  }
+}

--- a/backend/src/spot/dto/spot.object.ts
+++ b/backend/src/spot/dto/spot.object.ts
@@ -76,4 +76,7 @@ export class Spot {
 
   @Field(() => [SpotImage])
   images: SpotImage[];
+
+  @Field(() => Boolean, { nullable: true })
+  isLiked?: boolean | null;
 }

--- a/backend/src/spot/spot.module.ts
+++ b/backend/src/spot/spot.module.ts
@@ -3,9 +3,10 @@ import { SpotService } from './spot.service';
 import { SpotResolver } from './spot.resolver';
 import { UserModule } from '../user/user.module';
 import { SpotLoader } from './spot.loader';
+import { LikeModule } from '../like/like.module';
 
 @Module({
-  imports: [UserModule],
+  imports: [UserModule, LikeModule],
   providers: [SpotResolver, SpotService, SpotLoader],
   exports: [SpotService],
 })

--- a/backend/src/spot/spot.resolver.ts
+++ b/backend/src/spot/spot.resolver.ts
@@ -7,6 +7,7 @@ import {
   ID,
   ResolveField,
   Parent,
+  Context,
 } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
 import { SpotService } from './spot.service';
@@ -17,10 +18,11 @@ import { Category } from 'src/category/dto/category.object';
 import { SpotImage } from './dto/spot.object';
 import { CreateSpotInput } from './dto/create-spot.input';
 import { UpdateSpotInput } from './dto/update-spot.input';
-import { GqlAuthGuard } from '../auth/auth.guard';
+import { GqlAuthGuard, OptionalGqlAuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { AuthUser } from 'src/auth/types/auth-user.type';
 import { SpotLoader } from './spot.loader';
+import { LikeLoader } from '../like/like.loader';
 import { SpotConnection } from './dto/spot-connection.object';
 import { SpotSortInput } from './dto/spot-sort.input';
 import { SpotFilterInput } from './dto/spot-filter.input';
@@ -31,6 +33,7 @@ export class SpotResolver {
     private spotService: SpotService,
     private spotLoader: SpotLoader,
     private userService: UserService,
+    private likeLoader: LikeLoader,
   ) {}
 
   @Mutation(() => Spot)
@@ -43,6 +46,7 @@ export class SpotResolver {
     return this.spotService.create(user.id, input);
   }
 
+  @UseGuards(OptionalGqlAuthGuard)
   @Query(() => Spot, { name: 'spot', nullable: true })
   async getSpot(
     @Args('id', { type: () => ID }) id: string,
@@ -50,6 +54,7 @@ export class SpotResolver {
     return this.spotService.findById(id);
   }
 
+  @UseGuards(OptionalGqlAuthGuard)
   @Query(() => SpotConnection, { name: 'spots' })
   async getSpots(
     @Args('first', { type: () => Int, nullable: true, defaultValue: 20 })
@@ -97,5 +102,16 @@ export class SpotResolver {
   @ResolveField(() => [SpotImage])
   async images(@Parent() spot: { id: string }): Promise<SpotImage[]> {
     return this.spotLoader.imagesLoader.load(spot.id);
+  }
+
+  @ResolveField(() => Boolean, { nullable: true })
+  async isLiked(
+    @Parent() spot: { id: string },
+    @Context() ctx: { req: { user?: AuthUser } },
+  ): Promise<boolean | null> {
+    if (!ctx.req.user) return null;
+    return this.likeLoader.isLikedLoader.load(
+      `${ctx.req.user.supabaseId}:${spot.id}`,
+    );
   }
 }


### PR DESCRIPTION
## 関連Issue
Closes #112
Closes #114 
Closes #115 
Closes #116 
Closes #117 

## 変更の背景
いいね機能のバックエンドが未実装で、スポットへのいいね・いいね解除ができなかった。

## 変更内容
- `LikeResult` DTO を作成（liked: boolean, likeCount: number）
- `LikeService` に `toggleLike`（トランザクション）、`isLiked`、`getLikedSpotIdsByUser` を実装
- `LikeLoader` を作成（DataLoader で isLiked の N+1 を回避）
- `LikeResolver` に `toggleLike` Mutation を実装（認証必須）
- `Spot` ObjectType に `isLiked` フィールドを追加
- `SpotResolver` に `isLiked` ResolveField を追加
- `OptionalGqlAuthGuard` を追加（トークンありなら検証、なしでもエラーにしない）
- `getSpot` / `getSpots` Query に `OptionalGqlAuthGuard` を適用

## 変更の種類
- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他:

## 動作確認
- [x] ローカルで動作確認済み

## 迷った点・今後の課題
- `@UseGuards` は `@ResolveField` に対して正しく動作しないため、Query レベルに `OptionalGqlAuthGuard` を適用した
- `isLiked` の DataLoader はドキュメントの MVP 方針（N+1 許容）を先取りして実装した