### PR TITLE
feat(backend): マイページ用クエリの実装

### DIFF
--- a/backend/src/user/user.resolver.ts
+++ b/backend/src/user/user.resolver.ts
@@ -1,7 +1,8 @@
-import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
+import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
 import { UserService } from './user.service';
 import { User } from './dto/user.object';
+import { SpotConnection } from '../spot/dto/spot-connection.object';
 import { GqlAuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { AuthUser } from 'src/auth/types/auth-user.type';
@@ -20,6 +21,30 @@ export class UserResolver {
   @Query(() => User, { name: 'user', nullable: true })
   getUser(@Args('id') id: string): Promise<User | null> {
     return this.userService.findById(id);
+  }
+
+  @Query(() => SpotConnection, { name: 'mySpots' })
+  @UseGuards(GqlAuthGuard)
+  async getMySpots(
+    @CurrentUser() authUser: AuthUser,
+    @Args('first', { type: () => Int, nullable: true, defaultValue: 20 })
+    first: number,
+    @Args('after', { type: () => String, nullable: true }) after?: string,
+  ): Promise<SpotConnection> {
+    const user = await this.userService.getOrCreateUser(authUser);
+    return this.userService.mySpots(user.id, first, after);
+  }
+
+  @Query(() => SpotConnection, { name: 'myLikedSpots' })
+  @UseGuards(GqlAuthGuard)
+  async getMyLikedSpots(
+    @CurrentUser() authUser: AuthUser,
+    @Args('first', { type: () => Int, nullable: true, defaultValue: 20 })
+    first: number,
+    @Args('after', { type: () => String, nullable: true }) after?: string,
+  ): Promise<SpotConnection> {
+    const user = await this.userService.getOrCreateUser(authUser);
+    return this.userService.myLikedSpots(user.id, first, after);
   }
 
   @Mutation(() => User)

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,6 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'prisma/prisma.service';
+import { Prisma } from '@prisma/client';
 import type { AuthUser } from 'src/auth/types/auth-user.type';
+import {
+  SpotConnection,
+  SpotEdge,
+  PageInfo,
+} from '../spot/dto/spot-connection.object';
 
 @Injectable()
 export class UserService {
@@ -44,5 +50,109 @@ export class UserService {
       where: { id },
       data,
     });
+  }
+
+  async mySpots(
+    userId: string,
+    first: number = 20,
+    after?: string,
+  ): Promise<SpotConnection> {
+    const take = first + 1;
+    const where: Prisma.SpotWhereInput = { userId };
+
+    if (after) {
+      const cursor = this.decodeCursor(after);
+      where.createdAt = { lt: new Date(cursor.createdAt) };
+    }
+
+    const spots = await this.prisma.spot.findMany({
+      where,
+      take,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        images: { orderBy: { order: 'asc' } },
+        user: true,
+        category: true,
+      },
+    });
+
+    const hasNextPage = spots.length > first;
+    const result = hasNextPage ? spots.slice(0, first) : spots;
+    const totalCount = await this.prisma.spot.count({ where: { userId } });
+
+    const edges: SpotEdge[] = result.map((spot) => ({
+      node: spot,
+      cursor: this.encodeCursor(spot.createdAt),
+    }));
+
+    const pageInfo: PageInfo = {
+      hasNextPage,
+      hasPreviousPage: !!after,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    };
+
+    return { edges, pageInfo, totalCount };
+  }
+
+  async myLikedSpots(
+    userId: string,
+    first: number = 20,
+    after?: string,
+  ): Promise<SpotConnection> {
+    const take = first + 1;
+    const where: Prisma.LikeWhereInput = { userId };
+
+    if (after) {
+      const cursor = this.decodeCursor(after);
+      where.createdAt = { lt: new Date(cursor.createdAt) };
+    }
+
+    const likes = await this.prisma.like.findMany({
+      where,
+      take,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        spot: {
+          include: {
+            images: { orderBy: { order: 'asc' } },
+            user: true,
+            category: true,
+          },
+        },
+      },
+    });
+
+    const hasNextPage = likes.length > first;
+    const result = hasNextPage ? likes.slice(0, first) : likes;
+    const totalCount = await this.prisma.like.count({ where: { userId } });
+
+    const edges: SpotEdge[] = result.map((like) => ({
+      node: like.spot,
+      cursor: this.encodeCursor(like.createdAt),
+    }));
+
+    const pageInfo: PageInfo = {
+      hasNextPage,
+      hasPreviousPage: !!after,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    };
+
+    return { edges, pageInfo, totalCount };
+  }
+
+  private encodeCursor(createdAt: Date): string {
+    return Buffer.from(
+      JSON.stringify({ createdAt: createdAt.toISOString() }),
+    ).toString('base64');
+  }
+
+  private decodeCursor(cursor: string): { createdAt: string } {
+    try {
+      return JSON.parse(Buffer.from(cursor, 'base64').toString('utf-8'));
+    } catch {
+      throw new Error('Invalid cursor');
+    }
   }
 }


### PR DESCRIPTION
## 関連Issue
Closes #122
Closes #124 
Closes #125 
Closes #126 

## 変更の背景
マイページで自分の投稿一覧・いいね一覧を取得する API が未実装だった。

## 変更内容
- `UserService` に `mySpots`・`myLikedSpots` メソッドを追加
- `UserResolver` に `mySpots`・`myLikedSpots` Query を追加（認証必須）
- カーソルベースのページネーション対応（createdAt DESC）
- `myLikedSpots` は Like テーブルを経由して紐づく Spot を返す

## 変更の種類
- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他:

## 動作確認
- [x] ローカルで動作確認済み

## 迷った点・今後の課題
特になし。