### PR TITLE
fix(frontend): (main) layout に force-dynamic を一括設定

### DIFF
--- a/frontend/src/app/(main)/layout.tsx
+++ b/frontend/src/app/(main)/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic";
+
+export default function MainLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/(main)/mypage/edit/page.tsx
+++ b/frontend/src/app/(main)/mypage/edit/page.tsx
@@ -1,7 +1,5 @@
 import { ProfileEditContent } from "@/components/mypage/ProfileEditContent";
 
-export const dynamic = "force-dynamic";
-
 export default function ProfileEditPage() {
   return <ProfileEditContent />;
 }

--- a/frontend/src/app/(main)/mypage/page.tsx
+++ b/frontend/src/app/(main)/mypage/page.tsx
@@ -1,7 +1,5 @@
 import { MyPageContent } from "@/components/mypage/MyPageContent";
 
-export const dynamic = "force-dynamic";
-
 export default function MyPage() {
   return <MyPageContent />;
 }


### PR DESCRIPTION
## 関連Issue
Closes #146

## 変更の背景
PR #147 でページごとに個別対応したが、ページが増えるたびに漏れが発生する構造だった。Railway ビルドで `/spots/new` でも同様のエラーが発生したため、根本的に解決する。

## 変更内容
- `(main)/layout.tsx` を新規作成し `export const dynamic = "force-dynamic"` を設定
  - `(main)` 配下の全ページに自動で適用されるため、今後ページを追加しても対応不要
- `mypage/page.tsx` と `mypage/edit/page.tsx` の個別 `force-dynamic` を削除（layout で一括管理するため冗長）

## 変更の種類
- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他:

## 動作確認
- [x] ローカルで動作確認済み

## 迷った点・今後の課題
特になし。