### PR TITLE
fix(frontend): Supabase クライアントのビルド時初期化エラーを修正

### DIFF
--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,6 +1,10 @@
 import { createClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase: SupabaseClient =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey)
+    : (null as unknown as SupabaseClient);


### PR DESCRIPTION
## 関連Issue
Closes #149 

## 変更の背景
PR #147・#148 で `force-dynamic` を設定したが、`/_not-found`（Next.js 組み込みの404ページ）はルートレイアウト経由で Supabase が読み込まれるため、引き続きビルドが失敗していた。根本原因は `lib/supabase.ts` がモジュール評価時に env var がない場合 throw することだった。

## 変更内容
- `lib/supabase.ts` の `createClient` 呼び出しを env var がない場合に throw しないよう修正
- env var が未設定のビルド環境では `null` を返し、throw を回避する

## 変更の種類
- [x] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他:

## 動作確認
- [x] `NEXT_PUBLIC_SUPABASE_URL=""` でローカルビルドが通ることを確認済み

## 迷った点・今後の課題
特になし。
