### PR TITLE
test(backend): buildWhereClauseを純粋関数に切り出しユニットテストを追加

### DIFF
--- a/backend/src/spot/spot-filter.util.spec.ts
+++ b/backend/src/spot/spot-filter.util.spec.ts
@@ -1,0 +1,142 @@
+import { buildWhereClause } from './spot-filter.util';
+import { TagSearchMode } from './dto/tag-search-mode.enum';
+
+describe('buildWhereClause', () => {
+  describe('フィルターなし', () => {
+    it('引数なしのとき空オブジェクトを返す', () => {
+      expect(buildWhereClause()).toEqual({});
+    });
+
+    it('空のフィルターオブジェクトのとき空オブジェクトを返す', () => {
+      expect(buildWhereClause({})).toEqual({});
+    });
+  });
+
+  describe('カテゴリ絞り込み', () => {
+    it('categoryIds を指定すると in 条件になる', () => {
+      const result = buildWhereClause({ categoryIds: ['cat-1', 'cat-2'] });
+      expect(result).toEqual({ categoryId: { in: ['cat-1', 'cat-2'] } });
+    });
+
+    it('categoryIds が空配列のとき条件に含まれない', () => {
+      const result = buildWhereClause({ categoryIds: [] });
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('タグ OR 検索（デフォルト）', () => {
+    it('attributeTagIds を OR モードで指定すると some/in 条件になる', () => {
+      const result = buildWhereClause({
+        attributeTagIds: ['tag-1', 'tag-2'],
+        tagSearchMode: TagSearchMode.OR,
+      });
+      expect(result).toEqual({
+        attributeTags: { some: { tagId: { in: ['tag-1', 'tag-2'] } } },
+      });
+    });
+
+    it('tagSearchMode 未指定はOR扱いになる', () => {
+      const result = buildWhereClause({ moodTagIds: ['tag-a'] });
+      expect(result).toEqual({
+        moodTags: { some: { tagId: { in: ['tag-a'] } } },
+      });
+    });
+  });
+
+  describe('タグ AND 検索', () => {
+    it('attributeTagIds を AND モードで指定するとタグごとに some 条件を生成する', () => {
+      const result = buildWhereClause({
+        attributeTagIds: ['tag-1', 'tag-2'],
+        tagSearchMode: TagSearchMode.AND,
+      });
+      expect(result).toEqual({
+        AND: [
+          { attributeTags: { some: { tagId: 'tag-1' } } },
+          { attributeTags: { some: { tagId: 'tag-2' } } },
+        ],
+      });
+    });
+
+    it('moodTagIds を AND モードで指定するとタグごとに some 条件を生成する', () => {
+      const result = buildWhereClause({
+        moodTagIds: ['mood-1', 'mood-2'],
+        tagSearchMode: TagSearchMode.AND,
+      });
+      expect(result).toEqual({
+        AND: [
+          { moodTags: { some: { tagId: 'mood-1' } } },
+          { moodTags: { some: { tagId: 'mood-2' } } },
+        ],
+      });
+    });
+
+    it('AND モードで attributeTagIds と moodTagIds を両方指定すると AND 配列にまとめられる', () => {
+      const result = buildWhereClause({
+        attributeTagIds: ['tag-1'],
+        moodTagIds: ['mood-1'],
+        tagSearchMode: TagSearchMode.AND,
+      });
+      expect(result).toEqual({
+        AND: [
+          { attributeTags: { some: { tagId: 'tag-1' } } },
+          { moodTags: { some: { tagId: 'mood-1' } } },
+        ],
+      });
+    });
+  });
+
+  describe('キーワード検索', () => {
+    it('keyword を指定すると title と description の OR 条件が AND にネストされる', () => {
+      const result = buildWhereClause({ keyword: '渋谷' });
+      expect(result).toEqual({
+        AND: [
+          {
+            OR: [
+              { title: { contains: '渋谷', mode: 'insensitive' } },
+              { description: { contains: '渋谷', mode: 'insensitive' } },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('条件の組み合わせ（OR キー衝突の防止）', () => {
+    it('AND タグ検索 + キーワード検索を同時に指定しても OR キーが衝突しない', () => {
+      const result = buildWhereClause({
+        attributeTagIds: ['tag-1'],
+        tagSearchMode: TagSearchMode.AND,
+        keyword: '渋谷',
+      });
+      expect(result).toEqual({
+        AND: [
+          { attributeTags: { some: { tagId: 'tag-1' } } },
+          {
+            OR: [
+              { title: { contains: '渋谷', mode: 'insensitive' } },
+              { description: { contains: '渋谷', mode: 'insensitive' } },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('カテゴリ + キーワード検索を同時に指定できる', () => {
+      const result = buildWhereClause({
+        categoryIds: ['cat-1'],
+        keyword: '渋谷',
+      });
+      expect(result).toEqual({
+        categoryId: { in: ['cat-1'] },
+        AND: [
+          {
+            OR: [
+              { title: { contains: '渋谷', mode: 'insensitive' } },
+              { description: { contains: '渋谷', mode: 'insensitive' } },
+            ],
+          },
+        ],
+      });
+    });
+  });
+});

--- a/backend/src/spot/spot-filter.util.ts
+++ b/backend/src/spot/spot-filter.util.ts
@@ -1,0 +1,55 @@
+import { Prisma } from '@prisma/client';
+import { SpotFilterInput } from './dto/spot-filter.input';
+import { TagSearchMode } from './dto/tag-search-mode.enum';
+
+export function buildWhereClause(
+  filter?: SpotFilterInput,
+): Prisma.SpotWhereInput {
+  if (!filter) return {};
+
+  const where: Prisma.SpotWhereInput = {};
+
+  if (filter.categoryIds && filter.categoryIds.length > 0) {
+    where.categoryId = { in: filter.categoryIds };
+  }
+
+  const mode = filter.tagSearchMode ?? TagSearchMode.OR;
+
+  if (filter.attributeTagIds && filter.attributeTagIds.length > 0) {
+    if (mode === TagSearchMode.AND) {
+      const conditions = filter.attributeTagIds.map((tagId) => ({
+        attributeTags: { some: { tagId } },
+      }));
+      where.AND = [...((where.AND as object[]) ?? []), ...conditions];
+    } else {
+      where.attributeTags = {
+        some: { tagId: { in: filter.attributeTagIds } },
+      };
+    }
+  }
+
+  if (filter.moodTagIds && filter.moodTagIds.length > 0) {
+    if (mode === TagSearchMode.AND) {
+      const conditions = filter.moodTagIds.map((tagId) => ({
+        moodTags: { some: { tagId } },
+      }));
+      where.AND = [...((where.AND as object[]) ?? []), ...conditions];
+    } else {
+      where.moodTags = {
+        some: { tagId: { in: filter.moodTagIds } },
+      };
+    }
+  }
+
+  if (filter.keyword) {
+    const keywordCondition: Prisma.SpotWhereInput = {
+      OR: [
+        { title: { contains: filter.keyword, mode: 'insensitive' } },
+        { description: { contains: filter.keyword, mode: 'insensitive' } },
+      ],
+    };
+    where.AND = [...((where.AND as object[]) ?? []), keywordCondition];
+  }
+
+  return where;
+}

--- a/backend/src/spot/spot.service.ts
+++ b/backend/src/spot/spot.service.ts
@@ -9,7 +9,7 @@ import { CreateSpotInput } from './dto/create-spot.input';
 import { UpdateSpotInput } from './dto/update-spot.input';
 import { SpotSortBy, SortOrder, SpotSortInput } from './dto/spot-sort.input';
 import { SpotFilterInput } from './dto/spot-filter.input';
-import { TagSearchMode } from './dto/tag-search-mode.enum';
+import { buildWhereClause } from './spot-filter.util';
 import {
   SpotConnection,
   SpotEdge,
@@ -171,7 +171,7 @@ export class SpotService {
     const order = sort?.order ?? SortOrder.DESC;
 
     const orderBy = this.buildOrderBy(sortBy, order);
-    const filterWhere = this.buildWhereClause(filter);
+    const filterWhere = buildWhereClause(filter);
     const cursorCondition = after
       ? this.buildCursorCondition(after, sortBy, order)
       : null;
@@ -216,56 +216,6 @@ export class SpotService {
       pageInfo,
       totalCount,
     };
-  }
-
-  private buildWhereClause(filter?: SpotFilterInput): Prisma.SpotWhereInput {
-    if (!filter) return {};
-
-    const where: Prisma.SpotWhereInput = {};
-
-    if (filter.categoryIds && filter.categoryIds.length > 0) {
-      where.categoryId = { in: filter.categoryIds };
-    }
-
-    const mode = filter.tagSearchMode ?? TagSearchMode.OR;
-
-    if (filter.attributeTagIds && filter.attributeTagIds.length > 0) {
-      if (mode === TagSearchMode.AND) {
-        const conditions = filter.attributeTagIds.map((tagId) => ({
-          attributeTags: { some: { tagId } },
-        }));
-        where.AND = [...((where.AND as object[]) ?? []), ...conditions];
-      } else {
-        where.attributeTags = {
-          some: { tagId: { in: filter.attributeTagIds } },
-        };
-      }
-    }
-
-    if (filter.moodTagIds && filter.moodTagIds.length > 0) {
-      if (mode === TagSearchMode.AND) {
-        const conditions = filter.moodTagIds.map((tagId) => ({
-          moodTags: { some: { tagId } },
-        }));
-        where.AND = [...((where.AND as object[]) ?? []), ...conditions];
-      } else {
-        where.moodTags = {
-          some: { tagId: { in: filter.moodTagIds } },
-        };
-      }
-    }
-
-    if (filter.keyword) {
-      const keywordCondition: Prisma.SpotWhereInput = {
-        OR: [
-          { title: { contains: filter.keyword, mode: 'insensitive' } },
-          { description: { contains: filter.keyword, mode: 'insensitive' } },
-        ],
-      };
-      where.AND = [...((where.AND as object[]) ?? []), keywordCondition];
-    }
-
-    return where;
   }
 
   /**


### PR DESCRIPTION
## 関連Issue
Closes #153
Closes #154 

## 変更の背景
`buildWhereClause` は AND/OR検索モードの分岐・キーワード検索のORネスト・カーソル条件との合成など複雑なロジックを持つが、テストがなかった。将来PostGISなどのスキーマ変更を加えるときにリグレッションを検知できるようにするため、テストを追加した。

## 変更内容
- `buildWhereClause` を `SpotService` の private メソッドから `spot-filter.util.ts` の export 関数として切り出した
- `spot-filter.util.spec.ts` にユニットテスト12件を追加
- `spot.service.ts` は切り出した関数を呼ぶように変更（ロジックの変更なし）

## 変更の種類
- [x] リファクタリング
- [x] 新機能（テスト追加）

## 動作確認
- [x] ローカルで動作確認済み
- [x] `npm test` で12テスト全件パス
- [x] `npm run build` でビルド成功

## 迷った点・今後の課題
- privateのままキャストでテストする方法・`findMany`経由で統合テストする方法も検討したが、DBモックが不要でセットアップが簡単な純粋関数への切り出しを採用
- 実際にPrismaへ渡したときのSQL生成の正しさは確認できていない。統合テストは今後の課題