### PR TITLE
test(backend): カーソル関連処理をpure関数に切り出しユニットテストを追加

### DIFF
--- a/backend/src/spot/spot-cursor.util.spec.ts
+++ b/backend/src/spot/spot-cursor.util.spec.ts
@@ -1,0 +1,152 @@
+import {
+  encodeCursor,
+  decodeCursor,
+  buildCursorCondition,
+  CursorData,
+} from './spot-cursor.util';
+import { SpotSortBy, SortOrder } from './dto/spot-sort.input';
+
+const BASE_DATE = new Date('2024-01-15T10:00:00.000Z');
+const BASE_DATE_ISO = BASE_DATE.toISOString();
+
+describe('encodeCursor', () => {
+  it('CREATED_AT ソートのとき id と createdAt だけを含む', () => {
+    const cursor = encodeCursor(
+      { id: 'spot-1', createdAt: BASE_DATE },
+      SpotSortBy.CREATED_AT,
+    );
+    const decoded = JSON.parse(Buffer.from(cursor, 'base64').toString('utf-8'));
+
+    expect(decoded).toEqual({ id: 'spot-1', createdAt: BASE_DATE_ISO });
+  });
+
+  it('LIKE_COUNT ソートのとき likeCount も含む', () => {
+    const cursor = encodeCursor(
+      { id: 'spot-1', createdAt: BASE_DATE, likeCount: 42 },
+      SpotSortBy.LIKE_COUNT,
+    );
+    const decoded = JSON.parse(Buffer.from(cursor, 'base64').toString('utf-8'));
+
+    expect(decoded).toEqual({
+      id: 'spot-1',
+      createdAt: BASE_DATE_ISO,
+      likeCount: 42,
+    });
+  });
+
+  it('TITLE ソートのとき title も含む', () => {
+    const cursor = encodeCursor(
+      { id: 'spot-1', createdAt: BASE_DATE, title: '渋谷カフェ' },
+      SpotSortBy.TITLE,
+    );
+    const decoded = JSON.parse(Buffer.from(cursor, 'base64').toString('utf-8'));
+
+    expect(decoded).toEqual({
+      id: 'spot-1',
+      createdAt: BASE_DATE_ISO,
+      title: '渋谷カフェ',
+    });
+  });
+});
+
+describe('decodeCursor', () => {
+  it('encodeCursor で生成したカーソルを正しくデコードできる', () => {
+    const original = { id: 'spot-1', createdAt: BASE_DATE, likeCount: 10 };
+    const cursor = encodeCursor(original, SpotSortBy.LIKE_COUNT);
+    const decoded = decodeCursor(cursor);
+
+    expect(decoded).toEqual({
+      id: 'spot-1',
+      createdAt: BASE_DATE_ISO,
+      likeCount: 10,
+    });
+  });
+
+  it('不正な文字列を渡すと Error を投げる', () => {
+    expect(() => decodeCursor('not-valid-base64!!')).toThrow('Invalid cursor');
+  });
+
+  it('base64 だが JSON でない文字列を渡すと Error を投げる', () => {
+    const notJson = Buffer.from('hello').toString('base64');
+    expect(() => decodeCursor(notJson)).toThrow('Invalid cursor');
+  });
+});
+
+describe('buildCursorCondition', () => {
+  const cursorData: CursorData = {
+    id: 'spot-1',
+    createdAt: BASE_DATE_ISO,
+    likeCount: 5,
+    title: '渋谷カフェ',
+  };
+
+  describe('CREATED_AT ソート', () => {
+    it('DESC のとき createdAt の lt 条件になる', () => {
+      const result = buildCursorCondition(
+        cursorData,
+        SpotSortBy.CREATED_AT,
+        SortOrder.DESC,
+      );
+      expect(result).toEqual({ createdAt: { lt: new Date(BASE_DATE_ISO) } });
+    });
+
+    it('ASC のとき createdAt の gt 条件になる', () => {
+      const result = buildCursorCondition(
+        cursorData,
+        SpotSortBy.CREATED_AT,
+        SortOrder.ASC,
+      );
+      expect(result).toEqual({ createdAt: { gt: new Date(BASE_DATE_ISO) } });
+    });
+  });
+
+  describe('TITLE ソート', () => {
+    it('DESC のとき title の lt 条件になる', () => {
+      const result = buildCursorCondition(
+        cursorData,
+        SpotSortBy.TITLE,
+        SortOrder.DESC,
+      );
+      expect(result).toEqual({ title: { lt: '渋谷カフェ' } });
+    });
+
+    it('ASC のとき title の gt 条件になる', () => {
+      const result = buildCursorCondition(
+        cursorData,
+        SpotSortBy.TITLE,
+        SortOrder.ASC,
+      );
+      expect(result).toEqual({ title: { gt: '渋谷カフェ' } });
+    });
+  });
+
+  describe('LIKE_COUNT ソート', () => {
+    it('DESC のとき likeCount の lt 条件と同数タイの createdAt 条件を OR で返す', () => {
+      const result = buildCursorCondition(
+        cursorData,
+        SpotSortBy.LIKE_COUNT,
+        SortOrder.DESC,
+      );
+      expect(result).toEqual({
+        OR: [
+          { likeCount: { lt: 5 } },
+          { likeCount: 5, createdAt: { lt: new Date(BASE_DATE_ISO) } },
+        ],
+      });
+    });
+
+    it('ASC のとき likeCount の gt 条件と同数タイの createdAt 条件を OR で返す', () => {
+      const result = buildCursorCondition(
+        cursorData,
+        SpotSortBy.LIKE_COUNT,
+        SortOrder.ASC,
+      );
+      expect(result).toEqual({
+        OR: [
+          { likeCount: { gt: 5 } },
+          { likeCount: 5, createdAt: { lt: new Date(BASE_DATE_ISO) } },
+        ],
+      });
+    });
+  });
+});

--- a/backend/src/spot/spot-cursor.util.ts
+++ b/backend/src/spot/spot-cursor.util.ts
@@ -1,0 +1,66 @@
+import { Prisma } from '@prisma/client';
+import { SpotSortBy, SortOrder } from './dto/spot-sort.input';
+
+export type CursorData = {
+  id: string;
+  createdAt: string;
+  likeCount?: number;
+  title?: string;
+};
+
+type CursorSource = {
+  id: string;
+  createdAt: Date;
+  likeCount?: number;
+  title?: string;
+};
+
+export function encodeCursor(spot: CursorSource, sortBy: SpotSortBy): string {
+  const data: CursorData = {
+    id: spot.id,
+    createdAt: spot.createdAt.toISOString(),
+  };
+
+  if (sortBy === SpotSortBy.LIKE_COUNT) {
+    data.likeCount = spot.likeCount;
+  }
+  if (sortBy === SpotSortBy.TITLE) {
+    data.title = spot.title;
+  }
+
+  return Buffer.from(JSON.stringify(data)).toString('base64');
+}
+
+export function decodeCursor(cursor: string): CursorData {
+  try {
+    return JSON.parse(Buffer.from(cursor, 'base64').toString('utf-8'));
+  } catch {
+    throw new Error('Invalid cursor');
+  }
+}
+
+export function buildCursorCondition(
+  cursorData: CursorData,
+  sortBy: SpotSortBy,
+  order: SortOrder,
+): Prisma.SpotWhereInput {
+  const operator = order === SortOrder.DESC ? 'lt' : 'gt';
+
+  switch (sortBy) {
+    case SpotSortBy.LIKE_COUNT:
+      return {
+        OR: [
+          { likeCount: { [operator]: cursorData.likeCount } },
+          {
+            likeCount: cursorData.likeCount,
+            createdAt: { lt: new Date(cursorData.createdAt) },
+          },
+        ],
+      };
+    case SpotSortBy.TITLE:
+      return { title: { [operator]: cursorData.title } };
+    case SpotSortBy.CREATED_AT:
+    default:
+      return { createdAt: { [operator]: new Date(cursorData.createdAt) } };
+  }
+}

--- a/backend/src/spot/spot.service.ts
+++ b/backend/src/spot/spot.service.ts
@@ -11,6 +11,11 @@ import { SpotSortBy, SortOrder, SpotSortInput } from './dto/spot-sort.input';
 import { SpotFilterInput } from './dto/spot-filter.input';
 import { buildWhereClause } from './spot-filter.util';
 import {
+  encodeCursor,
+  decodeCursor,
+  buildCursorCondition,
+} from './spot-cursor.util';
+import {
   SpotConnection,
   SpotEdge,
   PageInfo,
@@ -173,7 +178,7 @@ export class SpotService {
     const orderBy = this.buildOrderBy(sortBy, order);
     const filterWhere = buildWhereClause(filter);
     const cursorCondition = after
-      ? this.buildCursorCondition(after, sortBy, order)
+      ? buildCursorCondition(decodeCursor(after), sortBy, order)
       : null;
 
     const where: Prisma.SpotWhereInput = cursorCondition
@@ -199,7 +204,7 @@ export class SpotService {
 
     const edges: SpotEdge[] = resultSpots.map((spot) => ({
       node: spot,
-      cursor: this.encodeCursor(spot, sortBy),
+      cursor: encodeCursor(spot, sortBy),
     }));
 
     const totalCount = await this.prisma.spot.count({ where: filterWhere });
@@ -219,37 +224,6 @@ export class SpotService {
   }
 
   /**
-   * カーソル条件を構築
-   */
-  private buildCursorCondition(
-    cursor: string,
-    sortBy: SpotSortBy,
-    order: SortOrder,
-  ) {
-    const cursorData = this.decodeCursor(cursor);
-    const operator = order === SortOrder.DESC ? 'lt' : 'gt';
-
-    switch (sortBy) {
-      case SpotSortBy.LIKE_COUNT:
-        // いいね順: likeCount で比較、同数なら createdAt で比較
-        return {
-          OR: [
-            { likeCount: { [operator]: cursorData.likeCount } },
-            {
-              likeCount: cursorData.likeCount,
-              createdAt: { lt: new Date(cursorData.createdAt) },
-            },
-          ],
-        };
-      case SpotSortBy.TITLE:
-        return { title: { [operator]: cursorData.title } };
-      case SpotSortBy.CREATED_AT:
-      default:
-        return { createdAt: { [operator]: new Date(cursorData.createdAt) } };
-    }
-  }
-
-  /**
    * ソート条件に応じた orderBy を構築
    */
   private buildOrderBy(sortBy: SpotSortBy, order: SortOrder) {
@@ -265,34 +239,4 @@ export class SpotService {
     }
   }
 
-  /**
-   * カーソルをエンコード（ソート条件に応じた値を含める）
-   */
-  private encodeCursor(spot: any, sortBy: SpotSortBy): string {
-    const data: any = {
-      id: spot.id,
-      createdAt: spot.createdAt.toISOString(),
-    };
-
-    // ソート対象の値もカーソルに含める
-    if (sortBy === SpotSortBy.LIKE_COUNT) {
-      data.likeCount = spot.likeCount;
-    }
-    if (sortBy === SpotSortBy.TITLE) {
-      data.title = spot.title;
-    }
-
-    return Buffer.from(JSON.stringify(data)).toString('base64');
-  }
-
-  /**
-   * カーソルをデコード
-   */
-  private decodeCursor(cursor: string): any {
-    try {
-      return JSON.parse(Buffer.from(cursor, 'base64').toString('utf-8'));
-    } catch {
-      throw new Error('Invalid cursor');
-    }
-  }
 }


### PR DESCRIPTION
## 関連Issue
Closes #156
Closes #157 

## 変更の背景
`encodeCursor` / `decodeCursor` / `buildCursorCondition` の3つはロジックの分岐があるにも関わらずテストがなかった。特に `buildCursorCondition` は LIKE_COUNT ソート時の同数タイ処理など壊れやすい箇所があるため、テストで保証する。

## 変更内容
- 3関数を `spot-cursor.util.ts` に pure 関数として切り出した
- `buildCursorCondition` の引数を `cursor: string` から `CursorData` に変更し、`decodeCursor` への依存を除去した
- `encodeCursor` の引数 `spot: any` を `CursorSource` 型に変更した
- `spot-cursor.util.spec.ts` にユニットテスト12件を追加

## 変更の種類
- [x] リファクタリング
- [x] 新機能（テスト追加）

## 動作確認
- [x] ローカルで動作確認済み
- [x] `npm test` で12テスト全件パス
- [x] `npm run build` でビルド成功

## 迷った点・今後の課題
- `buildCursorCondition` の引数変更により `decodeCursor` と責務が明確に分離された
- cursorはユーザーが触れる外部入力に近いため、エラー系テストも含めた