### PR TITLE
feat(frontend): ヘッダー・ナビゲーションのUI洗練

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -196,10 +196,18 @@ components:
   like-button-active:
     textColor: "{colors.like}"
   top-nav:
-    backgroundColor: "{colors.canvas}"
+    backgroundColor: "rgba(255, 255, 255, 0.9)"
+    backdropFilter: "blur(12px)"
     textColor: "{colors.ink}"
     border: "0 0 1px {colors.hairline} solid"
     height: 64px
+  top-nav-link:
+    textColor: "{colors.muted}"
+    fontSize: 14px
+    fontWeight: 500
+  top-nav-link-active:
+    textColor: "{colors.ink}"
+    underline: "2px solid {colors.primary-600}"
   avatar:
     backgroundColor: "{colors.surface-strong}"
     rounded: "{rounded.full}"
@@ -289,7 +297,12 @@ Noto Sans JP（`var(--font-noto-sans-jp)`、既存の`next/font/google`設定を
 ## Components
 
 ### ナビゲーション（`{component.top-nav}`）
-白背景・高さ64px・下端1pxのhairline。左にSpoteeロゴ（`text-primary-500`、大サイズなのでコントラスト要件を満たす）、右にナビゲーションリンクとログイン状態に応じたCTA。既存Header.tsxの構造をそのまま維持し、色トークンのみ差し替える。
+半透明の白背景（`bg-white/90` + `backdrop-blur`）・高さ64px・下端1pxのhairline。影は使わない。スクロール時にコンテンツがヘッダー下をうっすら透けて通る演出のため、キャンバス純白原則の唯一の例外としてヘッダーのみ半透明を許可する。
+
+- **ロゴ**: 左端に「Spotee」ワードマーク（24px・700・`text-primary-500`）＋末尾に`{colors.primary-600}`のドット。ナビリンク（14px・500）とのサイズ・ウェイト差で階層を作る。
+- **リンク**（`{component.top-nav-link}` / `-active`）: 通常は`{colors.muted}`相当のグレー、ホバーで`{colors.ink}`相当へ。ホバー・アクティブ時はリンク下端に2pxの`{colors.primary-600}`バーを`scale-x`（origin-left、200ms ease-out）で伸ばす。アクティブ状態はURLのパス前方一致で判定し、下線を常時表示する。
+- **CTA**: ログイン時は「スポットを投稿」、未ログイン時は「ログイン」を`button-primary`スタイルで右端に配置。押下時に`scale-95`の縮小を加える。
+- **モバイル（md未満）**: ナビを畳み、右端のハンバーガーボタン（44pxタップ領域、`aria-expanded`付き）でヘッダー直下にスライドダウンパネルを開閉する。パネル内はリンクを縦積みし、アクティブリンクは`{colors.primary-50}`背景＋`{colors.primary-700}`文字、CTAは全幅ボタンにする。ルート遷移時に自動で閉じる。
 
 ### 検索・フィルター
 - **カテゴリ選択**（`{component.category-pill}` / `{component.category-pill-active}`）: 1層目。アウトライン→選択時は`{colors.primary-600}`実線塗りのピル。

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,59 +1,198 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
 import { useAuth } from "@/hooks/useAuth";
+
+interface NavLinkProps {
+  href: string;
+  label: string;
+  active: boolean;
+}
+
+function NavLink({ href, label, active }: NavLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={`group relative py-2 text-sm font-medium transition-colors ${
+        active ? "text-gray-900" : "text-gray-600 hover:text-gray-900"
+      }`}
+    >
+      {label}
+      <span
+        className={`absolute inset-x-0 bottom-0 h-0.5 origin-left bg-primary-600 transition-transform duration-200 ease-out ${
+          active ? "scale-x-100" : "scale-x-0 group-hover:scale-x-100"
+        }`}
+      />
+    </Link>
+  );
+}
+
+interface MobileNavLinkProps {
+  href: string;
+  label: string;
+  active: boolean;
+}
+
+function MobileNavLink({ href, label, active }: MobileNavLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={`block rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+        active
+          ? "bg-primary-50 text-primary-700"
+          : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+      }`}
+    >
+      {label}
+    </Link>
+  );
+}
 
 export function Header() {
   const { user, loading, signOut } = useAuth();
+  const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [prevPathname, setPrevPathname] = useState(pathname);
+
+  if (prevPathname !== pathname) {
+    setPrevPathname(pathname);
+    setMenuOpen(false);
+  }
 
   const handleSignOut = async () => {
     await signOut();
   };
 
+  const isSpotsActive = pathname.startsWith("/spots");
+  const isMypageActive = pathname.startsWith("/mypage");
+
   return (
-    <header className="bg-white shadow-sm sticky top-0 z-50">
-      <div className="max-w-7xl mx-auto px-4">
-        <div className="flex justify-between items-center h-16">
-          <Link href="/" className="text-xl font-bold text-primary-500">
+    <header className="sticky top-0 z-50 border-b border-gray-200 bg-white/90 backdrop-blur-md">
+      <div className="mx-auto max-w-7xl px-4">
+        <div className="flex h-16 items-center justify-between">
+          <Link
+            href="/"
+            className="text-2xl font-bold tracking-tight text-primary-500"
+          >
             Spotee
+            <span className="text-primary-600">.</span>
           </Link>
 
-          <nav className="flex items-center gap-6">
-            <Link
-              href="/spots"
-              className="text-gray-600 hover:text-gray-900 transition-colors"
-            >
-              スポット一覧
-            </Link>
+          <nav className="hidden items-center gap-6 md:flex">
+            <NavLink href="/spots" label="スポット一覧" active={isSpotsActive} />
 
             {loading ? (
-              <div className="w-20 h-8 bg-gray-100 rounded animate-pulse" />
+              <div className="h-8 w-20 animate-pulse rounded bg-gray-100" />
             ) : user ? (
-              <div className="flex items-center gap-4">
-                <Link
+              <>
+                <NavLink
                   href="/mypage"
-                  className="text-gray-600 hover:text-gray-900 transition-colors"
-                >
-                  マイページ
-                </Link>
+                  label="マイページ"
+                  active={isMypageActive}
+                />
                 <button
                   onClick={handleSignOut}
-                  className="text-gray-600 hover:text-gray-900 transition-colors"
+                  className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
                 >
                   ログアウト
                 </button>
-              </div>
+                <Link
+                  href="/spots/new"
+                  className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-bold text-white transition hover:bg-primary-700 active:scale-95"
+                >
+                  スポットを投稿
+                </Link>
+              </>
             ) : (
               <Link
                 href="/login"
-                className="bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors"
+                className="rounded-lg bg-primary-600 px-4 py-2 text-sm font-bold text-white transition hover:bg-primary-700 active:scale-95"
               >
                 ログイン
               </Link>
             )}
           </nav>
+
+          <button
+            onClick={() => setMenuOpen((prev) => !prev)}
+            aria-expanded={menuOpen}
+            aria-label={menuOpen ? "メニューを閉じる" : "メニューを開く"}
+            className="-mr-2 flex h-11 w-11 items-center justify-center rounded-lg text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900 md:hidden"
+          >
+            <svg
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+            >
+              {menuOpen ? (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              ) : (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 7h16M4 12h16M4 17h16"
+                />
+              )}
+            </svg>
+          </button>
         </div>
       </div>
+
+      {menuOpen && (
+        <nav className="border-t border-gray-100 bg-white px-4 py-3 md:hidden">
+          <div className="space-y-1">
+            <MobileNavLink
+              href="/spots"
+              label="スポット一覧"
+              active={isSpotsActive}
+            />
+
+            {!loading && user && (
+              <MobileNavLink
+                href="/mypage"
+                label="マイページ"
+                active={isMypageActive}
+              />
+            )}
+          </div>
+
+          {!loading && (
+            <div className="mt-3 space-y-1 border-t border-gray-100 pt-3">
+              {user ? (
+                <>
+                  <Link
+                    href="/spots/new"
+                    className="block rounded-lg bg-primary-600 px-4 py-2.5 text-center text-sm font-bold text-white transition hover:bg-primary-700 active:scale-95"
+                  >
+                    スポットを投稿
+                  </Link>
+                  <button
+                    onClick={handleSignOut}
+                    className="block w-full rounded-lg px-3 py-2.5 text-left text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
+                  >
+                    ログアウト
+                  </button>
+                </>
+              ) : (
+                <Link
+                  href="/login"
+                  className="block rounded-lg bg-primary-600 px-4 py-2.5 text-center text-sm font-bold text-white transition hover:bg-primary-700 active:scale-95"
+                >
+                  ログイン
+                </Link>
+              )}
+            </div>
+          )}
+        </nav>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## 関連Issue
Closes #162

## 変更の背景
全画面共通のヘッダーがテキストリンクの横並びだけの単調な見た目で、階層・ホバー演出・現在地表示がなく、モバイルでも折りたたまれない状態だった。また`shadow-sm`を使っておりDESIGN.mdの`top-nav`定義（影ではなく下端1pxのhairline)とも不一致だった。

## 変更内容
### Header.tsx
- 土台: `shadow-sm`を廃止し`border-b` + `bg-white/90 backdrop-blur-md`に変更
- ロゴ: `text-2xl`に拡大し、末尾に`primary-600`のドットを付けたワードマークに変更。ナビリンクは14px/mediumに落として階層差を明確化
- ホバー・アクティブ: リンク下端に2pxの`primary-600`バーを`scale-x`アニメーション（200ms・origin-left）で表示。`usePathname()`の前方一致でアクティブページの下線を常時点灯
- CTA: ログイン時は「スポットを投稿」(`/spots/new`)、未ログイン時は「ログイン」を`button-primary`スタイルで右端に配置
- モバイル(md未満): ハンバーガーボタン（44pxタップ領域・`aria-expanded`付き）でスライドダウンパネルを開閉。ルート遷移時に自動クローズ

### DESIGN.md
- frontmatterの`top-nav`を半透明+blurに更新し、`top-nav-link` / `top-nav-link-active`トークンを新設
- 本文「ナビゲーション」節に下線アニメーション・CTA・モバイル挙動の仕様と、キャンバス純白原則の例外である旨を記載

## 変更の種類
- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] その他: UIデザイン改修

## 動作確認
- [x] ローカルで動作確認済み
- `npx tsc --noEmit` / `npm run lint`（エラー0件）/ `npm run build` すべて通過

## 迷った点・今後の課題
- 「ルート遷移でメニューを閉じる」処理を当初`useEffect`で書いたが`react-hooks/set-state-in-effect`エラーになったため、レンダー中に前回pathnameと比較して状態を調整するパターンに変更した（詳細は #169）
- モバイルパネルの開閉トランジションとESCキー対応は今後の課題
