### PR TITLE
feat(frontend): SpotCardを写真ファーストのレイアウトに刷新

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -133,11 +133,24 @@ components:
     backgroundColor: "{colors.canvas}"
     rounded: "{rounded.md}"
     border: "1px solid {colors.hairline-soft}"
+  spot-card-hover:
+    transform: "translateY(-2px)"
+    transition: "300ms"
   spot-card-image:
     rounded: "{rounded.md} {rounded.md} 0 0"
+  spot-card-image-hover:
+    transform: "scale(1.05)"
+    transition: "500ms ease-out"
   category-badge:
     backgroundColor: "{colors.primary-600}"
     textColor: "{colors.on-primary}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.full}"
+    padding: "4px 10px"
+  category-badge-overlay:
+    backgroundColor: "rgba(255, 255, 255, 0.9)"
+    backdropFilter: "blur(8px)"
+    textColor: "{colors.primary-700}"
     typography: "{typography.caption}"
     rounded: "{rounded.full}"
     padding: "4px 10px"
@@ -225,7 +238,7 @@ Spotee固有の設計判断として、**3層タグ構造をそのまま3つの�
 
 **Key Characteristics:**
 - 単色アクセント: `{colors.primary-600}`（通常表示）と`{colors.primary-700}`（ホバー・押下）の2段階がCTA・カテゴリバッジ・選択状態のすべてを担う。コード上は`bg-primary-600` / `hover:bg-primary-700` / `text-primary-500`という使い分けになる。
-- タグ3層 = 3色相: カテゴリ=ブルー実線バッジ、属性タグ=ティール、ムードタグ=パープル。いずれもソフトチップ（薄色背景＋濃色文字＋同系色ボーダー）で統一。
+- タグ3層 = 3色相: カテゴリ=ブルー、属性タグ=ティール、ムードタグ=パープル。カテゴリバッジは白背景上では`{colors.primary-600}`実線ピル（`{component.category-badge}`）、写真上では半透明白＋`{colors.primary-700}`文字のオーバーレイピル（`{component.category-badge-overlay}`）を使い、どちらもブルーの対応関係は維持する。属性・ムードはソフトチップ（薄色背景＋濃色文字＋同系色ボーダー）で統一。
 - 「いいね」はブランドカラーと独立させ、既存実装どおり`{colors.like}`（rose）を維持する。SNSの慣習（ブランド色と「いいね」色を分ける）に沿う。
 - 形状は控えめな丸み: カード12px、ボタン・入力欄8px、タグ・バッジ・アバターは完全ピル。角の丸さで層を作らず、色と塗り（実線かソフトかアウトラインか）で階層を作る。
 - キャンバスは純白。写真の発色を最優先し、暖色トーンのクリームは採用しない（Clayとの差別化にもなる）。
@@ -313,12 +326,17 @@ Noto Sans JP（`var(--font-noto-sans-jp)`、既存の`next/font/google`設定を
 - **AND/OR切り替え**（`{component.segmented-toggle}`）: 「いずれか」「すべて」の2択セグメントコントロール。選択側は`{colors.primary-600}`実線、非選択側は白背景。
 
 ### スポットカード（`{component.spot-card}`）
+
+写真ファーストの構成。視線が「写真 → タイトル → 住所 → 投稿者・いいね」の順に流れるよう、カテゴリバッジは画像上のオーバーレイに、いいねボタンは最下段のソーシャル情報行に配置する。
+
 - 画像: `aspect-video`、`{rounded.md}`の上2角のみ丸め。画像がない場合は`{colors.surface}`背景に「No Image」表示（既存実装を踏襲）。
-- カテゴリバッジ（`{component.category-badge}`）: 画像下、カード左上に`{colors.primary-600}`の実線ピル。
-- いいねボタン（`{component.like-button}` / `-active`）: カテゴリバッジと同じ行の右側。非アクティブは`{colors.muted}`、アクティブは`{colors.like}`塗りつぶしハート。
-- タイトル: `{typography.heading-sm}`、1行省略。
-- 住所: `{typography.body-sm}`、`{colors.muted}`、ピンアイコン付き1行省略。
-- 投稿者: 24pxの円形アバター＋名前（`{typography.body-sm}`）。
+- カテゴリバッジ（`{component.category-badge-overlay}`）: **画像左上のオーバーレイ**。半透明白（`bg-white/90` + `backdrop-blur`）のピルに`{colors.primary-700}`の文字。「カテゴリ＝ブルー」の対応は文字色で維持する。グリッドに実線ブルーのピルが並ぶ視覚ノイズを避けるため、またどんな写真の上でも喧嘩しないよう、塗りは白にする。
+- タイトル: `{typography.heading-sm}`、1行省略。コンテンツ部の先頭に置き、ホバー時に`{colors.primary-700}`へ変化してカード全体がリンクであることを示す。
+- 住所: `{typography.body-sm}`、`{colors.muted}`、ピンアイコン付き1行省略。タイトル直下に密に寄せ、スポット情報のグループを作る。
+- ソーシャル情報行: `{colors.hairline-soft}`の区切り線で上と分節し、左に投稿者（24px円形アバター＋名前`{typography.body-sm}`）、右にいいねボタン（`{component.like-button}` / `-active`）を配置。非アクティブは`{colors.muted}`、アクティブは`{colors.like}`塗りつぶしハート。
+- 余白リズム: コンテンツ部は16px（モバイル2カラム時は12px）。タイトル〜住所間は4pxで密に、区切り線の上下は12pxで疎に、均一な等間隔を避ける。
+- ホバー: 画像を`scale(1.05)`（500ms・ease-out）、カードは`shadow-sm → shadow-md` + 2pxのリフト（`{component.spot-card-hover}`）。動きは`transform`と影のみに限定する。
+- フォーカス: `focus-visible`時に`{colors.primary-300}`のリングを表示。
 
 ### スポット詳細
 - 画像ギャラリー: カルーセルまたはグリッド、`{rounded.lg}`。

--- a/frontend/src/components/spot/LikeButton.tsx
+++ b/frontend/src/components/spot/LikeButton.tsx
@@ -51,7 +51,7 @@ export function LikeButton({ spotId, likeCount, isLiked }: LikeButtonProps) {
     <button
       onClick={handleClick}
       disabled={loading}
-      className={`flex items-center gap-1 text-sm transition-colors disabled:opacity-50 ${
+      className={`flex items-center gap-1 p-2 -m-2 text-sm transition-colors disabled:opacity-50 ${
         isLiked
           ? "text-rose-500"
           : "text-gray-400 hover:text-rose-400"

--- a/frontend/src/components/spot/SpotCard.tsx
+++ b/frontend/src/components/spot/SpotCard.tsx
@@ -21,14 +21,17 @@ export function SpotCard({ spot }: SpotCardProps) {
   const firstImage = spot.images[0]?.url;
 
   return (
-    <Link href={`/spots/${spot.id}`}>
-      <article className="bg-white rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-shadow cursor-pointer">
-        <div className="aspect-video bg-gray-100 relative">
+    <Link
+      href={`/spots/${spot.id}`}
+      className="group block rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-300 focus-visible:ring-offset-2"
+    >
+      <article className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden transition duration-300 group-hover:shadow-md group-hover:-translate-y-0.5">
+        <div className="aspect-video bg-gray-100 relative overflow-hidden">
           {firstImage ? (
             <img
               src={firstImage}
               alt={spot.title}
-              className="w-full h-full object-cover"
+              className="w-full h-full object-cover transition-transform duration-500 ease-out group-hover:scale-105"
               loading="lazy"
             />
           ) : (
@@ -36,46 +39,45 @@ export function SpotCard({ spot }: SpotCardProps) {
               No Image
             </div>
           )}
+          <span className="absolute top-2.5 left-2.5 max-w-[calc(100%-20px)] truncate rounded-full bg-white/90 backdrop-blur px-2.5 py-1 text-xs font-medium text-primary-700">
+            {spot.category.name}
+          </span>
         </div>
 
-        <div className="p-4">
-          <div className="flex justify-between items-start mb-2">
-            <span className="text-xs text-white bg-primary-600 px-2 py-1 rounded">
-              {spot.category.name}
-            </span>
+        <div className="p-3 sm:px-4 sm:pb-4">
+          <h3 className="font-bold text-gray-900 line-clamp-1 transition-colors group-hover:text-primary-700">
+            {spot.title}
+          </h3>
+
+          <p className="mt-1 text-sm text-gray-500 line-clamp-1 flex items-center gap-1">
+            <MapPin size={13} className="shrink-0" />
+            {spot.address}
+          </p>
+
+          <div className="mt-3 pt-3 border-t border-gray-100 flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <div className="w-6 h-6 bg-gray-200 rounded-full overflow-hidden shrink-0">
+                {spot.user.avatarUrl ? (
+                  <img
+                    src={spot.user.avatarUrl}
+                    alt={spot.user.name}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center text-gray-400">
+                    <UserCircle size={24} />
+                  </div>
+                )}
+              </div>
+              <span className="text-sm text-gray-600 truncate">
+                {spot.user.name}
+              </span>
+            </div>
             <LikeButton
               spotId={spot.id}
               likeCount={spot.likeCount}
               isLiked={spot.isLiked ?? null}
             />
-          </div>
-
-          <h3 className="font-semibold text-gray-900 mb-1 line-clamp-1">
-            {spot.title}
-          </h3>
-
-          <p className="text-sm text-gray-500 line-clamp-1 flex items-center gap-1">
-            <MapPin size={13} className="flex-shrink-0" />
-            {spot.address}
-          </p>
-
-          <div className="mt-3 flex items-center gap-2">
-            <div className="w-6 h-6 bg-gray-200 rounded-full overflow-hidden flex-shrink-0">
-              {spot.user.avatarUrl ? (
-                <img
-                  src={spot.user.avatarUrl}
-                  alt={spot.user.name}
-                  className="w-full h-full object-cover"
-                />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center text-gray-400">
-                  <UserCircle size={24} />
-                </div>
-              )}
-            </div>
-            <span className="text-sm text-gray-600 truncate">
-              {spot.user.name}
-            </span>
           </div>
         </div>
       </article>

--- a/frontend/src/components/spot/SpotList.tsx
+++ b/frontend/src/components/spot/SpotList.tsx
@@ -100,22 +100,20 @@ export function SpotList({
 
 function SpotCardSkeleton() {
   return (
-    <div className="bg-white rounded-lg shadow-sm overflow-hidden animate-pulse">
+    <div className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden animate-pulse">
       <div className="aspect-video bg-gray-200" />
 
-      <div className="p-4 space-y-3">
-        <div className="flex justify-between">
-          <div className="h-5 w-16 bg-gray-200 rounded" />
-          <div className="h-5 w-10 bg-gray-200 rounded" />
-        </div>
-
+      <div className="p-3 sm:px-4 sm:pb-4">
         <div className="h-5 w-3/4 bg-gray-200 rounded" />
 
-        <div className="h-4 w-1/2 bg-gray-200 rounded" />
+        <div className="mt-2 h-4 w-1/2 bg-gray-200 rounded" />
 
-        <div className="flex items-center gap-2 pt-2">
-          <div className="w-6 h-6 bg-gray-200 rounded-full" />
-          <div className="h-4 w-20 bg-gray-200 rounded" />
+        <div className="mt-3 pt-3 border-t border-gray-100 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className="w-6 h-6 bg-gray-200 rounded-full" />
+            <div className="h-4 w-20 bg-gray-200 rounded" />
+          </div>
+          <div className="h-4 w-10 bg-gray-200 rounded" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 関連Issue
Closes #163
Closes #171 

## 変更の背景
Home・マイページ・スポット一覧で使い回されているSpotCardが、均一な`p-4`の余白と影の変化だけの「テンプレそのまま」な見た目になっていた。また、カード内で最初に目に入るのが青いカテゴリバッジで、主役であるべき写真・タイトルより視覚的に強く、グリッド表示では青いピルが並んで視覚ノイズになっていた。

## 変更内容
- **SpotCard.tsx**: 写真ファーストのレイアウトに刷新
  - カテゴリバッジを画像左上のオーバーレイ(半透明白+`primary-700`文字)に移動
  - いいねボタンを最下段へ移し、hairlineの区切り線で「投稿者+いいね」のソーシャル情報行として分節
  - ホバー演出を追加: 画像ズーム(`scale-105`・500ms)、カードリフト+影変化、タイトル色変化。すべて`transform`と影のみ
  - 角丸を`rounded-xl`(12px)に統一し、DESIGN.md定義のボーダーを追加
  - `focus-visible`リング追加、モバイル2カラム時はコンテンツ部を`p-3`に縮小
- **LikeButton.tsx**: 見た目を変えずに`p-2 -m-2`でタップ領域を拡大
- **SpotList.tsx**: `SpotCardSkeleton`を新レイアウトに同期
- **DESIGN.md**: 写真上用の`category-badge-overlay`トークンを新設(白背景用の実線`category-badge`はSpotDetail用に維持)。`spot-card-hover`等のトークン追加とスポットカードのセクションを新構成で更新

機能面の変更はなし。LikeButtonのprops・GraphQL・`stopPropagation`の挙動は従来どおり。

## 変更の種類
- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] その他: UIの改善

## 動作確認
- [x] ローカルで動作確認済み
  - Home・スポット一覧・マイページの3画面で表示確認(モバイル幅含む)
  - いいねボタンのトグルがカード遷移を妨げないことを確認
  - `tsc --noEmit`・`npm run build`が通ることを確認

## 迷った点・今後の課題
- カテゴリバッジの配色は「`primary-600`実線のまま画像上へ」「画像下のままソフトピル化」とも比較し、写真の発色を優先するDESIGN.mdの原則に合わせて白ピル+青文字を採用した
- `<img>`の`next/image`移行(LCP改善)は機能面の変更になるため別Issue候補として見送り
- ボーダー色が`gray-100`近似のため、`@theme`にhairline系トークンを追加したい
