### PR TITLE
feat(frontend): ログイン画面のUIをデザイントークンに沿って刷新

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,8 +1,34 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
+
+function Spinner({ className }: { className: string }) {
+  return (
+    <svg
+      className={`animate-spin ${className}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  );
+}
 
 export default function LoginPage() {
   const router = useRouter();
@@ -13,7 +39,7 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleEmailLogin = async (e: React.FormEvent) => {
+  const handleEmailLogin = async (e: React.SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
     setIsSubmitting(true);
@@ -37,33 +63,62 @@ export default function LoginPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        読み込み中...
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <Spinner className="h-6 w-6 text-primary-600" />
+        <span className="sr-only">読み込み中</span>
       </div>
     );
   }
 
+  const inputClassName =
+    "block w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-[15px] text-gray-900 placeholder:text-gray-400 transition focus:border-primary-700 focus:outline-none focus:ring-1 focus:ring-primary-700";
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <h1 className="text-center text-3xl font-bold text-gray-900">
-            Spotee にログイン
-          </h1>
-        </div>
-
-        {error && (
-          <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded">
-            {error}
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12">
+      <main className="w-full max-w-md">
+        <div className="rounded-2xl border border-gray-200 bg-white px-6 py-10 shadow-sm sm:px-10">
+          <div className="text-center">
+            <Link
+              href="/"
+              className="inline-block text-2xl font-bold tracking-tight text-primary-500"
+            >
+              Spotee
+              <span className="text-primary-600">.</span>
+            </Link>
+            <h1 className="mt-6 text-[22px] font-bold leading-snug text-gray-900">
+              Spotee にログイン
+            </h1>
+            <p className="mt-2 text-sm text-gray-500">
+              お気に入りの場所を見つけて、共有しよう
+            </p>
           </div>
-        )}
 
-        <form className="mt-8 space-y-6" onSubmit={handleEmailLogin}>
-          <div className="space-y-4">
+          {error && (
+            <div
+              role="alert"
+              className="mt-6 flex items-start gap-2.5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600"
+            >
+              <svg
+                className="mt-0.5 h-4 w-4 shrink-0"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              {error}
+            </div>
+          )}
+
+          <form className="mt-8 space-y-5" onSubmit={handleEmailLogin}>
             <div>
               <label
                 htmlFor="email"
-                className="block text-sm font-medium text-gray-700"
+                className="mb-1.5 block text-sm font-medium text-gray-700"
               >
                 メールアドレス
               </label>
@@ -71,17 +126,19 @@ export default function LoginPage() {
                 id="email"
                 name="email"
                 type="email"
+                autoComplete="email"
+                placeholder="mail@example.com"
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className={inputClassName}
               />
             </div>
 
             <div>
               <label
                 htmlFor="password"
-                className="block text-sm font-medium text-gray-700"
+                className="mb-1.5 block text-sm font-medium text-gray-700"
               >
                 パスワード
               </label>
@@ -89,51 +146,66 @@ export default function LoginPage() {
                 id="password"
                 name="password"
                 type="password"
+                autoComplete="current-password"
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className={inputClassName}
               />
             </div>
-          </div>
 
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-700 disabled:opacity-50"
-          >
-            {isSubmitting ? "ログイン中..." : "ログイン"}
-          </button>
-        </form>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-primary-700 active:scale-95 disabled:pointer-events-none disabled:opacity-50"
+            >
+              {isSubmitting && <Spinner className="h-4 w-4 text-white" />}
+              {isSubmitting ? "ログイン中..." : "ログイン"}
+            </button>
+          </form>
 
-        <div className="mt-6">
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-gray-300" />
-            </div>
-            <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-gray-50 text-gray-500">または</span>
-            </div>
+          <div className="mt-6 flex items-center gap-3">
+            <span className="h-px flex-1 bg-gray-200" />
+            <span className="text-xs text-gray-500">または</span>
+            <span className="h-px flex-1 bg-gray-200" />
           </div>
 
           <button
             onClick={handleGoogleLogin}
-            className="mt-4 w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
+            className="mt-6 flex w-full items-center justify-center gap-2.5 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-bold text-gray-900 transition hover:bg-gray-50 active:scale-95"
           >
+            <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                fill="#4285F4"
+                d="M23.49 12.27c0-.79-.07-1.54-.19-2.27H12v4.51h6.47a5.57 5.57 0 01-2.4 3.58v3h3.86c2.26-2.09 3.56-5.17 3.56-8.82z"
+              />
+              <path
+                fill="#34A853"
+                d="M12 24c3.24 0 5.95-1.08 7.93-2.91l-3.86-3c-1.08.72-2.45 1.16-4.07 1.16-3.13 0-5.78-2.11-6.73-4.96H1.29v3.09A11.99 11.99 0 0012 24z"
+              />
+              <path
+                fill="#FBBC05"
+                d="M5.27 14.29a7.19 7.19 0 010-4.58V6.62H1.29a11.99 11.99 0 000 10.76l3.98-3.09z"
+              />
+              <path
+                fill="#EA4335"
+                d="M12 4.75c1.77 0 3.35.61 4.6 1.8l3.42-3.42C17.95 1.19 15.24 0 12 0A11.99 11.99 0 001.29 6.62l3.98 3.09C6.22 6.86 8.87 4.75 12 4.75z"
+              />
+            </svg>
             Google でログイン
           </button>
         </div>
 
-        <p className="text-center text-sm text-gray-600">
+        <p className="mt-6 text-center text-sm text-gray-600">
           アカウントをお持ちでない方は{" "}
-          <a
+          <Link
             href="/register"
-            className="text-primary-500 hover:text-primary-600"
+            className="font-medium text-primary-600 transition-colors hover:text-primary-700 hover:underline"
           >
             新規登録
-          </a>
+          </Link>
         </p>
-      </div>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## 関連Issue
Closes #164
Closes #173 

## 変更の背景
ログイン画面がTailwind既定のフォームスタイル(枠線・角丸・配色すべて既定値)のまま残っており、第一印象に関わる画面としてブランドを感じられない状態だった。ヘッダーが付かない独立画面のため、画面単体でSpoteeブランドを認識できるデザインが必要だった。

## 変更内容
`frontend/src/app/(auth)/login/page.tsx`をDESIGN.mdのトークンに沿って刷新した。

- **レイアウト**: surface背景(gray-50)の中央に白カード(16px角丸+hairlineボーダー)を配置し、フォームを1つのオブジェクトとして見せる構成に変更
- **ブランド要素**: カード上部にHeaderと同じ「Spotee.」ワードマーク(`/`へのリンク)を追加
- **タイポグラフィ階層**: ワードマーク(24px/700) → 見出し22px/700 → 補助テキスト13px/mutedの3段階を新設
- **入力欄**: 影を除去し、フォーカスをグロー式(`ring-2`)からDESIGN.mdの「太さで示す」方式(`border`+`ring`各1pxでprimary-700の2px相当)へ変更。`autocomplete`属性とplaceholderを追加
- **ボタン**: ログインボタンにHeader CTAと同じ`active:scale-95`と送信中スピナーを追加。GoogleボタンにGロゴSVGを追加しbutton-secondaryスタイルに統一
- **エラー表示・ローディング**: 警告アイコン付きの`role="alert"`に変更、プレーンテキストだった読み込み中表示をスピナーに変更
- **新規登録リンク**: DESIGN.mdの原則(primary-500は本文サイズに使用禁止)に従いprimary-600へ変更。`<a>`を`next/link`に置き換え

機能面(認証フロー・リダイレクト)には手を入れていない。`/register`リンクは現状404だが、登録ページは別Issueで作成する方針のため残している。

## 変更の種類
- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] その他: UI改善

## 動作確認
- [x] ローカルで動作確認済み

## 迷った点・今後の課題
- `React.FormEvent`が@types/react 19系で非推奨になっていたため、`React.SubmitEvent<HTMLFormElement>`へ置き換えた。既存フォームにも同じパターンが残っているため後続Issueで対応したい
- 既存フォーム(SpotForm / ProfileEditForm / SearchBar)は旧グロー式フォーカスのまま。後続のUI洗練Issueで本PRのフォーカス表現に統一する
