### PR TITLE
feat(frontend): フィルターパネルのUIを刷新しモバイルボトムシートを改善

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -188,12 +188,19 @@ components:
     textColor: "{colors.on-primary}"
     border: "1px solid {colors.primary-600}"
   segmented-toggle:
-    backgroundColor: "{colors.canvas}"
-    rounded: "{rounded.sm}"
-    border: "1px solid {colors.hairline}"
+    backgroundColor: "{colors.surface-strong}"
+    rounded: "{rounded.full}"
+    padding: 2px
   segmented-toggle-active:
     backgroundColor: "{colors.primary-600}"
     textColor: "{colors.on-primary}"
+    rounded: "{rounded.full}"
+    transition: "transform 200ms ease-out"
+  filter-panel:
+    backgroundColor: "{colors.canvas}"
+    rounded: "{rounded.md}"
+    border: "1px solid {colors.hairline}"
+    padding: "{spacing.md}"
   text-input:
     backgroundColor: "{colors.canvas}"
     textColor: "{colors.ink}"
@@ -323,7 +330,16 @@ Noto Sans JP（`var(--font-noto-sans-jp)`、既存の`next/font/google`設定を
 - **ムードタグ**（`{component.mood-chip}` / `-active`）: 3層目。未選択時はグレーのアウトライン、選択時のみパープルのソフトチップに変わる。
 
 属性・ムードタグはカテゴリと違って複数同時選択が前提のため、選択時も`category-pill-active`のような濃い単色塗りにはしない。同時に複数選択されたときに濃い色のピルが並ぶと視覚的にうるさくなるため、選択状態は「薄色塗り＋同系色ボーダー」程度の弱いコントラストに留める。カテゴリは1つしか選択できないため、濃い単色塗りで強調しても画面がうるさくならない。
-- **AND/OR切り替え**（`{component.segmented-toggle}`）: 「いずれか」「すべて」の2択セグメントコントロール。選択側は`{colors.primary-600}`実線、非選択側は白背景。
+- **AND/OR切り替え**（`{component.segmented-toggle}`）: 「いずれか」「すべて」の2択セグメントコントロール。`{colors.surface-strong}`のグレーのピル型トラックの中を、`{colors.primary-600}`のサムが`translateX`（200ms・ease-out）でスライドする。動かすのはtransformのみで、レイアウトプロパティはアニメーションさせない。
+
+#### フィルターパネル（`{component.filter-panel}`）
+
+- パネルは`{rounded.md}`のカード（白背景＋hairlineボーダー、内側`{spacing.md}`）。カードの器は配置側（デスクトップの左サイドバー／モバイルのボトムシート）が持ち、パネル本体はコンテンツのみを描画する。
+- セクションは`{colors.hairline-soft}`の区切り線で分節する。見出し⇔チップ間は8pxで密に、セクションの上下は20pxで疎にし、均一な等間隔を避ける（SpotCardと同じ分節手法）。
+- パネル先頭に「絞り込み」見出し行を置き、フィルター選択中のみ右端に「クリア」テキストボタンを表示する。
+- セクション見出しには層の色相ドット（カテゴリ=ブルー、属性=ティール、ムード=パープル）と選択数バッジ（同系色のソフト配色・10px）を添え、3層×3色の対応をパネル自体でも視覚化する。
+- チップの演出: ホバーは同系色の薄背景＋ボーダー強調、押下時は`scale(0.95)`。選択時はチェックアイコンが`scale`イン（200ms）で出現し、`shadow-sm`（影1段階ルールの範囲内）で浮かせる。動きはtransform・色・影に限定する。
+- モバイル（lg未満）はボトムシート表示: `rounded-t-2xl`・上端にドラッグハンドル・黒40%の背景オーバーレイ。開閉はslide-up（300ms）＋背景フェード（200ms）。表示中は背景スクロールをロックし、下部固定フッターの「◯件のスポットを表示」全幅`button-primary`で閉じる。`prefers-reduced-motion`時はアニメーションを無効化する。
 
 ### スポットカード（`{component.spot-card}`）
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -23,6 +23,29 @@
   --color-primary-700: #1b34b8;
   --color-primary-800: #142883;
   --color-primary-900: #0e1c5c;
+
+  --animate-fade-in: fade-in 200ms ease-out;
+  --animate-sheet-up: sheet-up 300ms cubic-bezier(0.16, 1, 0.3, 1);
+  --animate-scale-in: scale-in 200ms ease-out;
+
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+  }
+
+  @keyframes sheet-up {
+    from {
+      transform: translateY(100%);
+    }
+  }
+
+  @keyframes scale-in {
+    from {
+      transform: scale(0);
+      opacity: 0;
+    }
+  }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -5,120 +5,215 @@ import { GET_ALL_TAGS } from '@/graphql/queries/tag';
 import { useSpotFilter, TagSearchMode } from '@/hooks/useSpotFilter';
 import type { GetAllTagsQuery } from '@/graphql/generated/graphql';
 
+interface SectionStyle {
+  dot: string;
+  badge: string;
+  chipSelected: string;
+  chipHover: string;
+}
+
+const SECTION_STYLES: Record<'category' | 'attribute' | 'mood', SectionStyle> = {
+  category: {
+    dot: 'bg-primary-600',
+    badge: 'bg-primary-50 text-primary-700',
+    chipSelected: 'bg-primary-600 text-white border-primary-600',
+    chipHover: 'hover:border-primary-400 hover:bg-primary-50/60',
+  },
+  attribute: {
+    dot: 'bg-emerald-500',
+    badge: 'bg-emerald-50 text-emerald-700',
+    chipSelected: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    chipHover: 'hover:border-emerald-300 hover:bg-emerald-50/60',
+  },
+  mood: {
+    dot: 'bg-purple-500',
+    badge: 'bg-purple-50 text-purple-700',
+    chipSelected: 'bg-purple-50 text-purple-700 border-purple-200',
+    chipHover: 'hover:border-purple-300 hover:bg-purple-50/60',
+  },
+};
+
+const SEARCH_MODES: [TagSearchMode, string][] = [
+  ['OR', 'いずれか'],
+  ['AND', 'すべて'],
+];
+
+function toggleIn(list: string[], id: string): string[] {
+  return list.includes(id) ? list.filter((v) => v !== id) : [...list, id];
+}
+
 export function FilterPanel() {
-  const { currentFilter, updateFilter } = useSpotFilter();
+  const { currentFilter, updateFilter, resetFilter, hasActiveFilter } = useSpotFilter();
   const { data, loading } = useQuery<GetAllTagsQuery>(GET_ALL_TAGS);
 
   if (loading) {
-    return <div className="animate-pulse h-48 bg-gray-100 rounded-lg" />;
+    return <FilterPanelSkeleton />;
   }
 
-  const toggleAttributeTag = (tagId: string) => {
-    const current = currentFilter.attributeTagIds;
-    const next = current.includes(tagId)
-      ? current.filter((id) => id !== tagId)
-      : [...current, tagId];
-    updateFilter({ attributeTagIds: next });
-  };
-
-  const toggleMoodTag = (tagId: string) => {
-    const current = currentFilter.moodTagIds;
-    const next = current.includes(tagId)
-      ? current.filter((id) => id !== tagId)
-      : [...current, tagId];
-    updateFilter({ moodTagIds: next });
-  };
+  const sections = [
+    {
+      label: 'カテゴリ',
+      items: data?.categories ?? [],
+      selectedIds: currentFilter.categoryIds,
+      style: SECTION_STYLES.category,
+      onToggle: (id: string) =>
+        updateFilter({ categoryIds: toggleIn(currentFilter.categoryIds, id) }),
+    },
+    {
+      label: '特徴タグ',
+      items: data?.attributeTags ?? [],
+      selectedIds: currentFilter.attributeTagIds,
+      style: SECTION_STYLES.attribute,
+      onToggle: (id: string) =>
+        updateFilter({ attributeTagIds: toggleIn(currentFilter.attributeTagIds, id) }),
+    },
+    {
+      label: 'ムードタグ',
+      items: data?.moodTags ?? [],
+      selectedIds: currentFilter.moodTagIds,
+      style: SECTION_STYLES.mood,
+      onToggle: (id: string) =>
+        updateFilter({ moodTagIds: toggleIn(currentFilter.moodTagIds, id) }),
+    },
+  ];
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-6">
-      <div>
-        <h3 className="text-sm font-semibold text-gray-700 mb-2">カテゴリ</h3>
-        <div className="flex flex-wrap gap-2">
-          {data?.categories?.map((cat: { id: string; name: string }) => {
-            const selected = currentFilter.categoryIds.includes(cat.id);
-            return (
-              <button
-                key={cat.id}
-                onClick={() => {
-                  const next = selected
-                    ? currentFilter.categoryIds.filter((id) => id !== cat.id)
-                    : [...currentFilter.categoryIds, cat.id];
-                  updateFilter({ categoryIds: next });
-                }}
-                className={`px-3 py-1 rounded-full text-sm border transition-colors ${
-                  selected
-                    ? 'bg-primary-600 text-white border-primary-600'
-                    : 'bg-white text-gray-600 border-gray-300 hover:border-primary-400'
-                }`}
-              >
-                {cat.name}
-              </button>
-            );
-          })}
-        </div>
+    <div>
+      <div className="flex items-center justify-between pb-4">
+        <h2 className="text-base font-bold text-gray-900">絞り込み</h2>
+        {hasActiveFilter && (
+          <button
+            onClick={resetFilter}
+            className="text-xs text-gray-400 hover:text-gray-600 underline transition-colors"
+          >
+            クリア
+          </button>
+        )}
       </div>
 
-      <div>
-        <h3 className="text-sm font-semibold text-gray-700 mb-2">特徴タグ</h3>
-        <div className="flex flex-wrap gap-2">
-          {data?.attributeTags?.map((tag: { id: string; name: string }) => (
-            <button
-              key={tag.id}
-              onClick={() => toggleAttributeTag(tag.id)}
-              className={`px-3 py-1 rounded-full text-sm border transition-colors ${
-                currentFilter.attributeTagIds.includes(tag.id)
-                  ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
-                  : 'bg-white text-gray-600 border-gray-300 hover:border-emerald-300'
-              }`}
-            >
-              {tag.name}
-            </button>
-          ))}
-        </div>
-      </div>
+      <div className="divide-y divide-gray-100">
+        {sections.map(({ label, items, selectedIds, style, onToggle }) => (
+          <section key={label} className="py-5 first:pt-0">
+            <div className="flex items-center gap-2 mb-2">
+              <span className={`w-1.5 h-1.5 rounded-full ${style.dot}`} aria-hidden="true" />
+              <h3 className="text-sm font-bold text-gray-700">{label}</h3>
+              {selectedIds.length > 0 && (
+                <span
+                  className={`min-w-4 h-4 px-1 inline-flex items-center justify-center rounded-full text-[10px] font-bold ${style.badge}`}
+                >
+                  {selectedIds.length}
+                </span>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {items.map((item: { id: string; name: string }) => (
+                <FilterChip
+                  key={item.id}
+                  label={item.name}
+                  selected={selectedIds.includes(item.id)}
+                  onClick={() => onToggle(item.id)}
+                  selectedClass={style.chipSelected}
+                  hoverClass={style.chipHover}
+                />
+              ))}
+            </div>
+          </section>
+        ))}
 
-      <div>
-        <h3 className="text-sm font-semibold text-gray-700 mb-2">ムードタグ</h3>
-        <div className="flex flex-wrap gap-2">
-          {data?.moodTags?.map((tag: { id: string; name: string }) => (
-            <button
-              key={tag.id}
-              onClick={() => toggleMoodTag(tag.id)}
-              className={`px-3 py-1 rounded-full text-sm border transition-colors ${
-                currentFilter.moodTagIds.includes(tag.id)
-                  ? 'bg-purple-50 text-purple-700 border-purple-200'
-                  : 'bg-white text-gray-600 border-gray-300 hover:border-purple-300'
+        <section className="pt-5">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="w-1.5 h-1.5 rounded-full bg-gray-400" aria-hidden="true" />
+            <h3 className="text-sm font-bold text-gray-700">タグの絞り込み方</h3>
+          </div>
+          <div className="relative grid grid-cols-2 max-w-56 rounded-full bg-gray-100 p-0.5">
+            <span
+              aria-hidden="true"
+              className={`absolute inset-y-0.5 left-0.5 w-[calc(50%-4px)] rounded-full bg-primary-600 shadow-sm transition-transform duration-200 ease-out motion-reduce:transition-none ${
+                currentFilter.tagSearchMode === 'AND'
+                  ? 'translate-x-[calc(100%+4px)]'
+                  : 'translate-x-0'
               }`}
-            >
-              {tag.name}
-            </button>
-          ))}
-        </div>
+            />
+            {SEARCH_MODES.map(([mode, label]) => {
+              const active = currentFilter.tagSearchMode === mode;
+              return (
+                <button
+                  key={mode}
+                  onClick={() => updateFilter({ tagSearchMode: mode })}
+                  aria-pressed={active}
+                  className={`relative py-1.5 text-sm rounded-full transition-colors ${
+                    active ? 'text-white font-bold' : 'text-gray-600 hover:text-gray-900'
+                  }`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-gray-400 mt-2">
+            {currentFilter.tagSearchMode === 'AND'
+              ? '選択したタグをすべて持つスポットを表示'
+              : '選択したタグのうちどれかを持つスポットを表示'}
+          </p>
+        </section>
       </div>
+    </div>
+  );
+}
 
-      <div>
-        <h3 className="text-sm font-semibold text-gray-700 mb-2">タグの絞り込み方</h3>
-        <div className="inline-flex rounded-lg border border-gray-200 overflow-hidden">
-          {([['OR', 'いずれか'], ['AND', 'すべて']] as [TagSearchMode, string][]).map(([mode, label]) => (
-            <button
-              key={mode}
-              onClick={() => updateFilter({ tagSearchMode: mode })}
-              className={`px-4 py-1.5 text-sm transition-colors ${
-                currentFilter.tagSearchMode === mode
-                  ? 'bg-primary-600 text-white'
-                  : 'bg-white text-gray-600 hover:bg-gray-50'
-              }`}
-            >
-              {label}
-            </button>
-          ))}
+interface FilterChipProps {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+  selectedClass: string;
+  hoverClass: string;
+}
+
+function FilterChip({ label, selected, onClick, selectedClass, hoverClass }: FilterChipProps) {
+  return (
+    <button
+      onClick={onClick}
+      aria-pressed={selected}
+      className={`inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm border transition duration-150 ease-out active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-300 ${
+        selected
+          ? `${selectedClass} shadow-sm`
+          : `bg-white text-gray-600 border-gray-300 ${hoverClass}`
+      }`}
+    >
+      {selected && (
+        <svg
+          className="w-3.5 h-3.5 animate-scale-in motion-reduce:animate-none"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={3}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      )}
+      {label}
+    </button>
+  );
+}
+
+function FilterPanelSkeleton() {
+  return (
+    <div className="animate-pulse" aria-hidden="true">
+      <div className="h-5 w-20 bg-gray-100 rounded mb-6" />
+      {[5, 6, 4].map((count, i) => (
+        <div key={i} className="mb-6">
+          <div className="h-4 w-16 bg-gray-100 rounded mb-3" />
+          <div className="flex flex-wrap gap-2">
+            {Array.from({ length: count }).map((_, j) => (
+              <div
+                key={j}
+                className={`h-8 rounded-full bg-gray-100 ${j % 2 === 0 ? 'w-16' : 'w-20'}`}
+              />
+            ))}
+          </div>
         </div>
-        <p className="text-xs text-gray-400 mt-1">
-          {currentFilter.tagSearchMode === 'AND'
-            ? '選択したタグをすべて持つスポットを表示'
-            : '選択したタグのうちどれかを持つスポットを表示'}
-        </p>
-      </div>
+      ))}
+      <div className="h-8 w-40 bg-gray-100 rounded-full" />
     </div>
   );
 }

--- a/frontend/src/components/spot/SpotsPageContent.tsx
+++ b/frontend/src/components/spot/SpotsPageContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@apollo/client/react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { GET_SPOTS } from "@/graphql/queries/spot";
 import { SpotList } from "@/components/spot/SpotList";
 import Link from "next/link";
@@ -22,6 +22,14 @@ export default function SpotsPageContent() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const { currentFilter, hasActiveFilter } = useSpotFilter();
+
+  useEffect(() => {
+    if (!isFilterOpen) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isFilterOpen]);
 
   const sortBy = (searchParams.get("sortBy") ?? SpotSortBy.CreatedAt) as SortOption["sortBy"];
   const order = (searchParams.get("order") ?? SortOrder.Desc) as SortOption["order"];
@@ -101,6 +109,7 @@ export default function SpotsPageContent() {
       user: { name: string; avatarUrl?: string | null };
     }>;
   const hasNextPage = data?.spots?.pageInfo?.hasNextPage ?? false;
+  const totalCount = data?.spots?.totalCount;
 
   return (
     <main className="min-h-screen bg-gray-50">
@@ -147,23 +156,39 @@ export default function SpotsPageContent() {
       {isFilterOpen && (
         <div className="fixed inset-0 z-50 lg:hidden">
           <div
-            className="absolute inset-0 bg-black/40"
+            className="absolute inset-0 bg-black/40 animate-fade-in motion-reduce:animate-none"
             onClick={() => setIsFilterOpen(false)}
           />
-          <div className="absolute bottom-0 left-0 right-0 bg-white rounded-t-2xl max-h-[80vh] overflow-y-auto">
-            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
-              <span className="font-semibold text-gray-800">絞り込み</span>
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="絞り込み"
+            className="absolute bottom-0 left-0 right-0 flex flex-col bg-white rounded-t-2xl max-h-[85vh] animate-sheet-up motion-reduce:animate-none"
+          >
+            <div className="relative flex justify-center pt-3 pb-2">
+              <span className="w-10 h-1 rounded-full bg-gray-300" aria-hidden="true" />
               <button
                 onClick={() => setIsFilterOpen(false)}
-                className="text-gray-400 hover:text-gray-600"
+                aria-label="閉じる"
+                className="absolute right-3 top-2 p-1.5 text-gray-400 hover:text-gray-600 transition-colors"
               >
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
             </div>
-            <div className="p-4">
+            <div className="overflow-y-auto px-5 py-4">
               <FilterPanel />
+            </div>
+            <div className="border-t border-gray-100 px-5 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
+              <button
+                onClick={() => setIsFilterOpen(false)}
+                className="w-full bg-primary-600 text-white text-sm font-bold py-3 rounded-lg hover:bg-primary-700 active:scale-[0.98] transition"
+              >
+                {typeof totalCount === "number"
+                  ? `${totalCount}件のスポットを表示`
+                  : "スポットを表示"}
+              </button>
             </div>
           </div>
         </div>
@@ -172,7 +197,9 @@ export default function SpotsPageContent() {
       <div className="max-w-7xl mx-auto px-4 py-8">
         <div className="flex gap-6">
           <aside className="hidden lg:block w-72 flex-shrink-0">
-            <FilterPanel />
+            <div className="bg-white border border-gray-200 rounded-xl p-4">
+              <FilterPanel />
+            </div>
           </aside>
           <div className="flex-1 min-w-0">
             <div className="mb-4">


### PR DESCRIPTION
## 関連Issue
Closes #165
Closes #175

## 変更の背景
配色（カテゴリ／属性／ムードの3色分け）は前回のPRで整理済みだったが、フィルターパネルは均一なチップが等間隔に並ぶだけの単調なレイアウトで、ホバー・選択のフィードバックも色変化のみだった。モバイルのボトムシートも開閉アニメーションがなく、表示中に背面がスクロールできるなど未洗練だった。

## 変更内容
`FilterPanel.tsx`を中心に、DESIGN.mdの余白リズム・モーション原則（transform/影のみ）に沿って刷新した。

- **セクション構造**: `space-y-6`の均一余白をやめ、hairline区切り＋密疎の余白（見出し⇔チップ8px、セクション間20px）で分節。パネル先頭に「絞り込み」見出し行を追加し、フィルター選択中のみ「クリア」ボタンを表示
- **3層×3色の視覚化**: 各セクション見出しに層の色相ドット（カテゴリ=ブルー、属性=ティール、ムード=パープル）と選択数バッジを追加
- **チップの演出強化**: 選択時にチェックアイコンがscaleインで出現＋`shadow-sm`で浮かせる。ホバーで同系色の薄背景、押下時`active:scale-95`、`focus-visible`リングと`aria-pressed`を追加
- **AND/ORトグル**: 白背景2ボタンから、グレーのピル型トラック内をprimary-600のサムが`translateX`でスライドするセグメントコントロールへ変更（追加のstateなし、`tagSearchMode`から導出）
- **モバイルボトムシート**: slide-up＋背景フェードの開閉アニメーション、ドラッグハンドル、下部固定フッター「◯件のスポットを表示」ボタンを追加。表示中は`body`のスクロールをロック。`prefers-reduced-motion`時はアニメーション無効
- **カードの器を配置側へ移動**: FilterPanelからカードchrome（枠・背景・padding）を外し、シート内でのカードinカード二重枠を解消
- **その他**: ローディングスケルトンをパネル構造に合わせた形状に変更。DESIGN.mdにフィルターパネル仕様を追記し、`segmented-toggle`トークンをピル型トラック方式に更新

検索・フィルターの機能面（URL反映・タグtoggleロジック）には手を入れていない。

## 変更の種類
- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [x] その他: UI改善

## 動作確認
- [x] ローカルで動作確認済み

## 迷った点・今後の課題
- ボトムシートのドラッグハンドルは視覚記号のみで、スワイプで閉じる操作は未実装。必要になったら別Issueで対応したい
- シート内のフォーカストラップ（Tab循環）は未対応
- チェックアイコンの出現でチップ幅がわずかに変わるが、wrapレイアウトのため実害なしと判断した