### PR TITLE
feat(frontend): UI洗練シリーズの積み残し改善

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,23 @@
 import type { NextConfig } from "next";
 
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      ...(supabaseUrl
+        ? [
+            {
+              protocol: "https" as const,
+              hostname: new URL(supabaseUrl).hostname,
+              pathname: "/storage/v1/object/public/**",
+            },
+          ]
+        : []),
+      { protocol: "https", hostname: "picsum.photos" },
+      { protocol: "https", hostname: "fastly.picsum.photos" },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/components/common/ImageUploader.tsx
+++ b/frontend/src/components/common/ImageUploader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import Image from "next/image";
 import { uploadImage } from "@/lib/storage";
 import imageCompression from "browser-image-compression";
 
@@ -116,10 +117,12 @@ export function ImageUploader({
               onDrop={(e) => handleDrop(e, index)}
               onDragOver={handleDragOver}
             >
-              <img
+              <Image
                 src={url}
                 alt={`アップロード画像 ${index + 1}`}
-                className="w-full h-full object-cover"
+                fill
+                sizes="(min-width: 768px) 20vw, (min-width: 640px) 33vw, 50vw"
+                className="object-cover"
               />
               <button
                 type="button"

--- a/frontend/src/components/home/HomeContent.tsx
+++ b/frontend/src/components/home/HomeContent.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import Link from "next/link";
 import { ArrowRight, Search } from "lucide-react";
 import { useQuery } from "@apollo/client/react";
@@ -39,10 +40,12 @@ function CollageCard({ spot, aspect }: CollageCardProps) {
       href={`/spots/${spot.id}`}
       className={`group relative block overflow-hidden rounded-xl border border-gray-100 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-300 focus-visible:ring-offset-2 ${aspect}`}
     >
-      <img
+      <Image
         src={imageUrl}
         alt={spot.title}
-        className="h-full w-full object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+        fill
+        sizes="(min-width: 1024px) 220px, 50vw"
+        className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
       />
       <span className="absolute left-2.5 top-2.5 max-w-[calc(100%-20px)] truncate rounded-full bg-white/90 px-2.5 py-1 text-xs font-medium text-primary-700 backdrop-blur">
         {spot.category.name}

--- a/frontend/src/components/mypage/MyPageContent.tsx
+++ b/frontend/src/components/mypage/MyPageContent.tsx
@@ -1,31 +1,98 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useQuery } from "@apollo/client/react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Camera, Heart, Pencil, UserCircle } from "lucide-react";
+import { Camera, Heart, Loader2, Pencil, UserCircle } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
+import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import { SpotCard } from "@/components/spot/SpotCard";
 import { SpotCardSkeleton } from "@/components/spot/SpotList";
 import { GET_ME, GET_MY_SPOTS, GET_MY_LIKED_SPOTS } from "@/graphql/queries/user";
 
 type Tab = "spots" | "liked";
 
+const PAGE_SIZE = 20;
+
 export function MyPageContent() {
   const { user, loading: authLoading } = useAuth();
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<Tab>("spots");
+  const [loadingMore, setLoadingMore] = useState(false);
 
   const { data: meData, loading: meLoading } = useQuery(GET_ME, { skip: !user });
-  const { data: spotsData, loading: spotsLoading } = useQuery(GET_MY_SPOTS, {
-    variables: { first: 20 },
+  const {
+    data: spotsData,
+    loading: spotsLoading,
+    fetchMore: fetchMoreSpots,
+  } = useQuery(GET_MY_SPOTS, {
+    variables: { first: PAGE_SIZE },
     skip: !user,
   });
-  const { data: likedData, loading: likedLoading } = useQuery(GET_MY_LIKED_SPOTS, {
-    variables: { first: 20 },
+  const {
+    data: likedData,
+    loading: likedLoading,
+    fetchMore: fetchMoreLiked,
+  } = useQuery(GET_MY_LIKED_SPOTS, {
+    variables: { first: PAGE_SIZE },
     skip: !user,
   });
+
+  const spotsPageInfo = spotsData?.mySpots?.pageInfo;
+  const likedPageInfo = likedData?.myLikedSpots?.pageInfo;
+  const activePageInfo = activeTab === "spots" ? spotsPageInfo : likedPageInfo;
+  const hasNextPage = activePageInfo?.hasNextPage ?? false;
+
+  const handleLoadMore = useCallback(async () => {
+    const endCursor = activePageInfo?.endCursor;
+    if (!endCursor || loadingMore) return;
+
+    setLoadingMore(true);
+    try {
+      if (activeTab === "spots") {
+        await fetchMoreSpots({
+          variables: { first: PAGE_SIZE, after: endCursor },
+          updateQuery: (prevResult, { fetchMoreResult }) => {
+            if (!fetchMoreResult) return prevResult;
+            return {
+              mySpots: {
+                ...fetchMoreResult.mySpots,
+                edges: [...prevResult.mySpots.edges, ...fetchMoreResult.mySpots.edges],
+              },
+            };
+          },
+        });
+      } else {
+        await fetchMoreLiked({
+          variables: { first: PAGE_SIZE, after: endCursor },
+          updateQuery: (prevResult, { fetchMoreResult }) => {
+            if (!fetchMoreResult) return prevResult;
+            return {
+              myLikedSpots: {
+                ...fetchMoreResult.myLikedSpots,
+                edges: [...prevResult.myLikedSpots.edges, ...fetchMoreResult.myLikedSpots.edges],
+              },
+            };
+          },
+        });
+      }
+    } catch (err) {
+      console.error("Failed to load more:", err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [activeTab, activePageInfo, loadingMore, fetchMoreSpots, fetchMoreLiked]);
+
+  const { targetRef, isIntersecting } = useIntersectionObserver<HTMLDivElement>({
+    enabled: hasNextPage && !loadingMore,
+  });
+
+  useEffect(() => {
+    if (isIntersecting && hasNextPage && !loadingMore) {
+      handleLoadMore();
+    }
+  }, [isIntersecting, hasNextPage, loadingMore, handleLoadMore]);
 
   if (authLoading) {
     return <div className="min-h-screen flex items-center justify-center">読み込み中...</div>;
@@ -173,11 +240,20 @@ export function MyPageContent() {
             )}
           </div>
         ) : (
-          <div className="grid grid-cols-2 gap-4 sm:gap-6 lg:grid-cols-3">
-            {activeSpots.map((spot) => (
-              <SpotCard key={spot.id} spot={spot} />
-            ))}
-          </div>
+          <>
+            <div className="grid grid-cols-2 gap-4 sm:gap-6 lg:grid-cols-3">
+              {activeSpots.map((spot) => (
+                <SpotCard key={spot.id} spot={spot} />
+              ))}
+            </div>
+            {loadingMore && (
+              <div className="flex items-center justify-center gap-2 py-8 text-sm text-gray-500">
+                <Loader2 size={18} className="animate-spin" aria-hidden="true" />
+                読み込み中...
+              </div>
+            )}
+            {hasNextPage && <div ref={targetRef} className="h-1" />}
+          </>
         )}
       </div>
     </main>

--- a/frontend/src/components/mypage/MyPageContent.tsx
+++ b/frontend/src/components/mypage/MyPageContent.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useQuery } from "@apollo/client/react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import Link from "next/link";
 import { Camera, Heart, Loader2, Pencil, UserCircle } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
@@ -129,7 +130,13 @@ export function MyPageContent() {
           <div className="flex items-start gap-4 sm:gap-6">
             <div className="w-20 h-20 sm:w-24 sm:h-24 rounded-full overflow-hidden bg-gray-200 shrink-0">
               {me?.avatarUrl ? (
-                <img src={me.avatarUrl} alt={me.name} className="w-full h-full object-cover" />
+                <Image
+                  src={me.avatarUrl}
+                  alt={me.name}
+                  width={96}
+                  height={96}
+                  className="w-full h-full object-cover"
+                />
               ) : (
                 <div className="w-full h-full flex items-center justify-center text-gray-400">
                   <UserCircle size={48} />

--- a/frontend/src/components/mypage/ProfileEditForm.tsx
+++ b/frontend/src/components/mypage/ProfileEditForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { Camera, UserCircle } from "lucide-react";
 import { useMutation } from "@apollo/client/react";
 import { UPDATE_PROFILE } from "@/graphql/mutations/user";
@@ -85,7 +86,13 @@ export function ProfileEditForm({
           aria-label="アバター画像を変更"
         >
           {avatarUrl ? (
-            <img src={avatarUrl} alt="アバター" className="w-full h-full object-cover" />
+            <Image
+              src={avatarUrl}
+              alt="アバター"
+              width={96}
+              height={96}
+              className="w-full h-full object-cover"
+            />
           ) : (
             <div className="w-full h-full flex items-center justify-center text-gray-400">
               <UserCircle size={48} />

--- a/frontend/src/components/search/FilterBottomSheet.tsx
+++ b/frontend/src/components/search/FilterBottomSheet.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { FilterPanel } from "./FilterPanel";
+
+interface FilterBottomSheetProps {
+  open: boolean;
+  totalCount?: number;
+  onClose: () => void;
+}
+
+const SWIPE_CLOSE_THRESHOLD_PX = 80;
+
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+export function FilterBottomSheet({ open, totalCount, onClose }: FilterBottomSheetProps) {
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const touchStartY = useRef<number | null>(null);
+  const [dragY, setDragY] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const getFocusable = () => {
+      const sheet = sheetRef.current;
+      if (!sheet) return [];
+      return Array.from(sheet.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (el) => !el.hasAttribute("disabled"),
+      );
+    };
+
+    getFocusable()[0]?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const focusable = getFocusable();
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartY.current = e.touches[0].clientY;
+    setIsDragging(true);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (touchStartY.current == null) return;
+    setDragY(Math.max(0, e.touches[0].clientY - touchStartY.current));
+  };
+
+  const handleTouchEnd = () => {
+    touchStartY.current = null;
+    setIsDragging(false);
+    if (dragY > SWIPE_CLOSE_THRESHOLD_PX) {
+      onClose();
+    }
+    setDragY(0);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 lg:hidden">
+      <div
+        className="absolute inset-0 bg-black/40 animate-fade-in motion-reduce:animate-none"
+        onClick={onClose}
+      />
+      <div
+        ref={sheetRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="絞り込み"
+        style={{
+          transform: dragY > 0 ? `translateY(${dragY}px)` : undefined,
+          transition: isDragging ? "none" : undefined,
+        }}
+        className="absolute bottom-0 left-0 right-0 flex flex-col bg-white rounded-t-2xl max-h-[85vh] animate-sheet-up motion-reduce:animate-none transition-transform duration-200 ease-out"
+      >
+        <div
+          className="relative flex justify-center pt-3 pb-2 touch-none"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
+          <span className="w-10 h-1 rounded-full bg-gray-300" aria-hidden="true" />
+          <button
+            onClick={onClose}
+            aria-label="閉じる"
+            className="absolute right-3 top-2 p-1.5 text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="overflow-y-auto px-5 py-4">
+          <FilterPanel />
+        </div>
+        <div className="border-t border-gray-100 px-5 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
+          <button
+            onClick={onClose}
+            className="w-full bg-primary-600 text-white text-sm font-bold py-3 rounded-lg hover:bg-primary-700 active:scale-[0.98] transition"
+          >
+            {typeof totalCount === "number"
+              ? `${totalCount}件のスポットを表示`
+              : "スポットを表示"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/spot/SpotCard.tsx
+++ b/frontend/src/components/spot/SpotCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { MapPin, UserCircle } from "lucide-react";
 import { LikeButton } from "@/components/spot/LikeButton";
@@ -28,11 +29,12 @@ export function SpotCard({ spot }: SpotCardProps) {
       <article className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden transition duration-300 group-hover:shadow-md group-hover:-translate-y-0.5">
         <div className="aspect-video bg-gray-100 relative overflow-hidden">
           {firstImage ? (
-            <img
+            <Image
               src={firstImage}
               alt={spot.title}
-              className="w-full h-full object-cover transition-transform duration-500 ease-out group-hover:scale-105"
-              loading="lazy"
+              fill
+              sizes="(min-width: 1024px) 300px, (min-width: 640px) 50vw, 100vw"
+              className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center text-gray-400">
@@ -58,9 +60,11 @@ export function SpotCard({ spot }: SpotCardProps) {
             <div className="flex items-center gap-2 min-w-0">
               <div className="w-6 h-6 bg-gray-200 rounded-full overflow-hidden shrink-0">
                 {spot.user.avatarUrl ? (
-                  <img
+                  <Image
                     src={spot.user.avatarUrl}
                     alt={spot.user.name}
+                    width={24}
+                    height={24}
                     className="w-full h-full object-cover"
                   />
                 ) : (

--- a/frontend/src/components/spot/SpotDetail.tsx
+++ b/frontend/src/components/spot/SpotDetail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
@@ -162,10 +163,13 @@ export function SpotDetail({ spot, isOwner = false }: SpotDetailProps) {
       <div className="mb-8">
         <div className="relative aspect-video overflow-hidden rounded-2xl bg-gray-100">
           {currentImage ? (
-            <img
+            <Image
               src={currentImage.url}
               alt={spot.title}
-              className="w-full h-full object-cover"
+              fill
+              priority
+              sizes="(min-width: 896px) 864px, 100vw"
+              className="object-cover"
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center text-gray-400">
@@ -193,9 +197,11 @@ export function SpotDetail({ spot, isOwner = false }: SpotDetailProps) {
                     : "opacity-60 hover:opacity-100"
                 }`}
               >
-                <img
+                <Image
                   src={image.url}
                   alt={`${spot.title} ${index + 1}`}
+                  width={64}
+                  height={64}
                   className="w-full h-full object-cover"
                 />
               </button>
@@ -284,9 +290,11 @@ export function SpotDetail({ spot, isOwner = false }: SpotDetailProps) {
             <div className="flex items-center gap-3">
               <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full bg-gray-200">
                 {spot.user.avatarUrl ? (
-                  <img
+                  <Image
                     src={spot.user.avatarUrl}
                     alt={spot.user.name}
+                    width={40}
+                    height={40}
                     className="w-full h-full object-cover"
                   />
                 ) : (

--- a/frontend/src/components/spot/SpotDetail.tsx
+++ b/frontend/src/components/spot/SpotDetail.tsx
@@ -211,46 +211,7 @@ export function SpotDetail({ spot, isOwner = false }: SpotDetailProps) {
       </div>
 
       <div className="grid gap-8 lg:grid-cols-3 lg:gap-10">
-        <div className="space-y-8 lg:col-span-2">
-          {spot.description && (
-            <section>
-              <h2 className="text-lg font-bold text-gray-900">
-                このスポットについて
-              </h2>
-              <p className="mt-3 whitespace-pre-wrap leading-relaxed text-gray-700">
-                {spot.description}
-              </p>
-            </section>
-          )}
-
-          {hasTags && (
-            <section>
-              <h2 className="text-lg font-bold text-gray-900">
-                このスポットの特徴
-              </h2>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {attributeTags.map((tag) => (
-                  <span
-                    key={tag.id}
-                    className="rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700"
-                  >
-                    {tag.name}
-                  </span>
-                ))}
-                {moodTags.map((tag) => (
-                  <span
-                    key={tag.id}
-                    className="rounded-full border border-purple-200 bg-purple-50 px-3 py-1.5 text-xs font-medium text-purple-700"
-                  >
-                    {tag.name}
-                  </span>
-                ))}
-              </div>
-            </section>
-          )}
-        </div>
-
-        <aside className="space-y-4">
+        <aside className="space-y-4 lg:order-2">
           <div className="rounded-xl border border-gray-200 p-5">
             <h2 className="text-sm font-bold text-gray-900">基本情報</h2>
             <dl className="mt-4 space-y-4 text-sm">
@@ -314,6 +275,45 @@ export function SpotDetail({ spot, isOwner = false }: SpotDetailProps) {
             </div>
           </div>
         </aside>
+
+        <div className="space-y-8 lg:col-span-2 lg:order-1">
+          {spot.description && (
+            <section>
+              <h2 className="text-lg font-bold text-gray-900">
+                このスポットについて
+              </h2>
+              <p className="mt-3 whitespace-pre-wrap leading-relaxed text-gray-700">
+                {spot.description}
+              </p>
+            </section>
+          )}
+
+          {hasTags && (
+            <section>
+              <h2 className="text-lg font-bold text-gray-900">
+                このスポットの特徴
+              </h2>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {attributeTags.map((tag) => (
+                  <span
+                    key={tag.id}
+                    className="rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700"
+                  >
+                    {tag.name}
+                  </span>
+                ))}
+                {moodTags.map((tag) => (
+                  <span
+                    key={tag.id}
+                    className="rounded-full border border-purple-200 bg-purple-50 px-3 py-1.5 text-xs font-medium text-purple-700"
+                  >
+                    {tag.name}
+                  </span>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/spot/SpotForm.tsx
+++ b/frontend/src/components/spot/SpotForm.tsx
@@ -148,7 +148,7 @@ export function SpotForm({ spotId, initialValues }: SpotFormProps) {
           id="title"
           type="text"
           {...register("title", { required: "スポット名は必須です" })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+          className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-[15px] text-gray-900 placeholder:text-gray-400 transition focus:border-primary-700 focus:outline-none focus:ring-1 focus:ring-primary-700"
           placeholder="例: 渋谷のおしゃれカフェ"
         />
         {errors.title && (
@@ -178,7 +178,7 @@ export function SpotForm({ spotId, initialValues }: SpotFormProps) {
           id="address"
           type="text"
           {...register("address", { required: "住所は必須です" })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+          className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-[15px] text-gray-900 placeholder:text-gray-400 transition focus:border-primary-700 focus:outline-none focus:ring-1 focus:ring-primary-700"
           placeholder="例: 東京都渋谷区〇〇1-2-3"
         />
         {errors.address && (
@@ -198,7 +198,7 @@ export function SpotForm({ spotId, initialValues }: SpotFormProps) {
           {...register("categoryId", {
             required: "カテゴリを選択してください",
           })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+          className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-[15px] text-gray-900 placeholder:text-gray-400 transition focus:border-primary-700 focus:outline-none focus:ring-1 focus:ring-primary-700"
         >
           <option value="">選択してください</option>
           {tagData?.categories.map((category) => (
@@ -225,7 +225,7 @@ export function SpotForm({ spotId, initialValues }: SpotFormProps) {
           id="description"
           {...register("description")}
           rows={4}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+          className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-[15px] text-gray-900 placeholder:text-gray-400 transition focus:border-primary-700 focus:outline-none focus:ring-1 focus:ring-primary-700"
           placeholder="このスポットの魅力を教えてください"
         />
       </div>
@@ -240,7 +240,7 @@ export function SpotForm({ spotId, initialValues }: SpotFormProps) {
         <select
           id="priceRange"
           {...register("priceRange", { valueAsNumber: true })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+          className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-[15px] text-gray-900 placeholder:text-gray-400 transition focus:border-primary-700 focus:outline-none focus:ring-1 focus:ring-primary-700"
         >
           <option value="">選択してください</option>
           <option value={1}>~1,000円</option>
@@ -261,7 +261,7 @@ export function SpotForm({ spotId, initialValues }: SpotFormProps) {
           id="businessHours"
           type="text"
           {...register("businessHours")}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+          className="w-full rounded-lg border border-gray-300 px-3.5 py-2.5 text-[15px] text-gray-900 placeholder:text-gray-400 transition focus:border-primary-700 focus:outline-none focus:ring-1 focus:ring-primary-700"
           placeholder="例: 10:00-22:00（定休日: 月曜）"
         />
       </div>

--- a/frontend/src/components/spot/SpotsPageContent.tsx
+++ b/frontend/src/components/spot/SpotsPageContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@apollo/client/react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { SlidersHorizontal } from "lucide-react";
 import { GET_SPOTS } from "@/graphql/queries/spot";
 import { SpotList } from "@/components/spot/SpotList";
@@ -11,6 +11,7 @@ import type { GetSpotsQuery, GetSpotsQueryVariables } from "@/graphql/generated/
 import { SpotSortBy, SortOrder, TagSearchMode } from "@/graphql/generated/graphql";
 import { SortSelect, SortOption } from "@/components/search/SortSelect";
 import { FilterPanel } from "@/components/search/FilterPanel";
+import { FilterBottomSheet } from "@/components/search/FilterBottomSheet";
 import { SearchBar } from "@/components/search/SearchBar";
 import { ActiveFilterChips } from "@/components/search/ActiveFilterChips";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -23,14 +24,6 @@ export default function SpotsPageContent() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const { currentFilter, hasActiveFilter } = useSpotFilter();
-
-  useEffect(() => {
-    if (!isFilterOpen) return;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [isFilterOpen]);
 
   const sortBy = (searchParams.get("sortBy") ?? SpotSortBy.CreatedAt) as SortOption["sortBy"];
   const order = (searchParams.get("order") ?? SortOrder.Desc) as SortOption["order"];
@@ -146,46 +139,11 @@ export default function SpotsPageContent() {
         </div>
       </div>
 
-      {isFilterOpen && (
-        <div className="fixed inset-0 z-50 lg:hidden">
-          <div
-            className="absolute inset-0 bg-black/40 animate-fade-in motion-reduce:animate-none"
-            onClick={() => setIsFilterOpen(false)}
-          />
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-label="絞り込み"
-            className="absolute bottom-0 left-0 right-0 flex flex-col bg-white rounded-t-2xl max-h-[85vh] animate-sheet-up motion-reduce:animate-none"
-          >
-            <div className="relative flex justify-center pt-3 pb-2">
-              <span className="w-10 h-1 rounded-full bg-gray-300" aria-hidden="true" />
-              <button
-                onClick={() => setIsFilterOpen(false)}
-                aria-label="閉じる"
-                className="absolute right-3 top-2 p-1.5 text-gray-400 hover:text-gray-600 transition-colors"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div className="overflow-y-auto px-5 py-4">
-              <FilterPanel />
-            </div>
-            <div className="border-t border-gray-100 px-5 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
-              <button
-                onClick={() => setIsFilterOpen(false)}
-                className="w-full bg-primary-600 text-white text-sm font-bold py-3 rounded-lg hover:bg-primary-700 active:scale-[0.98] transition"
-              >
-                {typeof totalCount === "number"
-                  ? `${totalCount}件のスポットを表示`
-                  : "スポットを表示"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <FilterBottomSheet
+        open={isFilterOpen}
+        totalCount={totalCount}
+        onClose={() => setIsFilterOpen(false)}
+      />
 
       <div className="max-w-7xl mx-auto px-4 py-8">
         <div className="flex gap-6">


### PR DESCRIPTION
## 関連Issue
Closes #184
Closes #199 

## 変更の背景
UI洗練シリーズ（#162〜#168）で意図的に先送りした改善項目の回収。Issueでは項目ごとにPRを分ける想定だったが、1ブランチ・1PRにまとめ、コミットは項目単位で分割した。

## 変更内容
- **マイページのページネーション対応**: スポット一覧と同じ `fetchMore` + `useIntersectionObserver` の無限スクロールパターンを移植し、`first: 20` 固定で21件以降の投稿・いいねが表示できない問題を修正
- **SpotFormのフォーカス統一**: グロー式（`ring-2` の薄色リング）から「太さで示す」方式（`focus:border-primary-700` + `ring-1`）へ統一。あわせて入力欄をDESIGN.mdのtext-input仕様（角丸8px・padding 10px/14px）に合わせた
- **`<img>` → `next/image` 移行**: SpotCard・スポット詳細ギャラリー・ホームのコラージュ・マイページ・プロフィール編集・ImageUploaderの全6ファイル。`next.config.ts` にSupabase Storageの `remotePatterns` を追加し、LCPになるスポット詳細のメイン画像のみ `priority` を指定
- **スポット詳細のモバイル表示順**: 基本情報・投稿者カードの `aside` をDOM上で先に置き、`lg:order-*` でデスクトップの2カラム配置は維持したまま、モバイルでは基本情報を説明文より先に表示
- **フィルターボトムシートの操作性向上**: `FilterBottomSheet` コンポーネントとして切り出し、ドラッグハンドルのスワイプで閉じる操作（80px超で確定・未満はスナップバック）、Tabのフォーカストラップ、Escapeで閉じる、閉じた際のフォーカス復元を追加

## 変更の種類
- [x] バグ修正
- [x] リファクタリング
- [x] その他: UI・アクセシビリティ改善

## 動作確認
- [x] ローカルで動作確認済み
  - `tsc --noEmit`・`eslint`（既存警告のみ）・`next build` すべて通過
  - devサーバーで `/_next/image` 経由のSupabase画像配信が200を返すことを確認
  - 実機タッチ操作でのスワイプ閉じは未確認（要実機チェック）

## 迷った点・今後の課題
- スワイプはドラッグハンドル領域のみ反応させた。コンテンツ部まで広げるとフィルター一覧の内部スクロールと競合するため
- マイページの追加読み込み中stateはタブ共通のため、読み込み中にタブを切り替えると両タブでスピナーが出る（実害は軽微と判断）
- `remotePatterns` にローカル負荷試験シードで使う picsum.photos も許可している